### PR TITLE
Fix vendor location

### DIFF
--- a/parallel-lint
+++ b/parallel-lint
@@ -40,6 +40,7 @@ $autoloadLocations = [
     getcwd() . '/../../autoload.php',
     __DIR__ . '/../vendor/autoload.php',
     __DIR__ . '/../../../autoload.php',
+    __DIR__ . '/../../autoload.php',
 ];
 
 $loaded = false;


### PR DESCRIPTION
Fixing issue with autoloader when executing from outside the source directory: https://github.com/php-parallel-lint/PHP-Parallel-Lint/issues/1