### PR TITLE
Travis: remove sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
     - php: 7.3
     - php: 7.4
 
-sudo: false
-
 install:
   - composer install --no-interaction --prefer-source
 


### PR DESCRIPTION
Travis has removed support for `sudo: false`. See: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration