### PR TITLE
CS: Various phpcs tweaks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,7 +11,6 @@
 /appveyor.yml export-ignore
 /box.json export-ignore
 /phpcs.xml.dist export-ignore
-/phpcs-ruleset.xml export-ignore
 /tests export-ignore
 
 #

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor
 composer.lock
+.phpcs.xml
+phpcs.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ script:
   - ./vendor/bin/tester -p php tests
   - ./parallel-lint --exclude vendor --exclude tests/examples --no-colors .
   - ./parallel-lint --exclude vendor --exclude tests/examples .
-  - if [[ "$SNIFF" == "1" ]]; then ./vendor/bin/phpcs --standard=phpcs-ruleset.xml -s src;fi
+  - if [[ "$SNIFF" == "1" ]]; then ./vendor/bin/phpcs;fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     - php: 7.2
     - php: 7.3
     - php: 7.4
+      env: SNIFF=1
     - php: "nightly"
 
   fast_finish: true
@@ -27,4 +28,4 @@ script:
   - ./vendor/bin/tester -p php tests
   - ./parallel-lint --exclude vendor --exclude tests/examples --no-colors .
   - ./parallel-lint --exclude vendor --exclude tests/examples .
-  - ./vendor/bin/phpcs --standard=phpcs-ruleset.xml -s src
+  - if [[ "$SNIFF" == "1" ]]; then ./vendor/bin/phpcs --standard=phpcs-ruleset.xml -s src;fi

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require-dev": {
         "nette/tester": "^1.3 || ^2.0",
         "php-parallel-lint/php-console-highlighter": "~0.3",
-        "squizlabs/php_codesniffer": "~3.0"
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "suggest": {
         "php-parallel-lint/php-console-highlighter": "Highlight syntax in code snippet"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,37 @@
 <?xml version="1.0"?>
-<ruleset name="PHP-Parallel-Lint">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP-Parallel-Lint" xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
     <description>PHP Parallel Lint coding standard.</description>
+
+    <!--
+    #############################################################################
+    COMMAND LINE ARGUMENTS
+    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+    #############################################################################
+    -->
+
+    <file>.</file>
+
+    <!-- Exclude the Examples directory and the Composer vendor directory. -->
+    <exclude-pattern>*/tests/examples/*</exclude-pattern>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+
+    <!-- Only check PHP files. -->
+    <arg name="extensions" value="php,phpt/php"/>
+
+    <!-- Show progress, show the error codes for each message (source). -->
+    <arg value="ps"/>
+
+    <!-- Strip the filepaths down to the relevant bit. -->
+    <arg name="basepath" value="./"/>
+
+    <!-- Check up to 8 files simultaneously. -->
+    <arg name="parallel" value="8"/>
+
+    <!--
+    #############################################################################
+    RULES
+    #############################################################################
+    -->
 
     <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
     <rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman"/>
@@ -20,7 +51,9 @@
 
     <rule ref="Generic.PHP.DisallowShortOpenTag"/>
     <rule ref="Generic.PHP.LowerCaseConstant"/>
-    <rule ref="Generic.PHP.NoSilencedErrors"/>
+    <rule ref="Generic.PHP.NoSilencedErrors">
+        <exclude-pattern>/bin/skip-linting\.php$</exclude-pattern>
+    </rule>
     <rule ref="Squiz.PHP.GlobalKeyword"/>
     <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
     <rule ref="Squiz.PHP.NonExecutableCode"/>

--- a/tests/Manager.run.phpt
+++ b/tests/Manager.run.phpt
@@ -19,7 +19,7 @@ class ManagerRunTest extends Tester\TestCase
         $settings = $this->prepareSettings();
         $settings->paths = array('path/for-not-found/');
         $manager = $this->getManager($settings);
-        Assert::exception(function() use ($manager, $settings) {
+        Assert::exception(function () use ($manager, $settings) {
             $manager->run($settings);
         }, 'JakubOnderka\PhpParallelLint\NotExistsPathException');
     }
@@ -29,7 +29,7 @@ class ManagerRunTest extends Tester\TestCase
         $settings = $this->prepareSettings();
         $settings->paths = array('examples/example-01/');
         $manager = $this->getManager($settings);
-        Assert::exception(function() use ($manager, $settings) {
+        Assert::exception(function () use ($manager, $settings) {
             $manager->run($settings);
         }, 'JakubOnderka\PhpParallelLint\Exception', 'No file found to check.');
     }


### PR DESCRIPTION
This is the same PR as previously pulled in PR JakubOnderka/PHP-Parallel-Lint#146


## Composer: update the PHPCS dependency

The current version is `3.5.4` released end of January 2020 and - aside from lots of bug fixes -, it includes compatibility with PHP 7.4.

See: https://github.com/squizlabs/php_codesniffer/releases

## Travis: only run PHPCS once

The results of PHPCS run will be no different across PHP versions as all sniffs are unit tested against all supported PHP versions, so it is unnecessary to run it against every PHP version, just run it once per build.

I've chosen to run it against PHP 7.4 as that's the fastest PHP version.

## PHPCS: tweak ruleset

* Rename the ruleset to one which PHPCS will recognize automatically.
    This means you no longer need to pass the `--standard` on the command-line.
* Use the `dist` extension to allow for devs to overload the ruleset file locally and gitignore the typical overload file names which are recognized by PHPCS by default.
* Ruleset/Travis: move command-line arguments to the project ruleset.
    ... and scan all PHP files, not just the files in `src`.
* Ruleset: also scan the `phpt` test files.
* Ruleset: enable parallel scanning.
* Ruleset: set the basepath for a cleaner output report.
* Ruleset: add the PHPCS XML scheme.
* Ruleset: selectively exclude the `skip-linting.php` file for the `Generic.PHP.NoSilencedErrors` rule.

## CS: minor clean up 