### PR TITLE
Travis: test against nightly (= PHP 8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,13 @@ matrix:
     - php: 7.2
     - php: 7.3
     - php: 7.4
+    - php: "nightly"
+
+  fast_finish: true
+
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: "nightly"
 
 sudo: false
 


### PR DESCRIPTION
Adding a build against `nightly` (PHP 8) which, for now, is allowed to fail.

At this time, there is one unit test which fails `ParallelLint.lint.phpt method=testDeprecated`. This will need to be investigated over time. No urgency yet as it may be related to the Nette testing framework dependency and also PHP 8 is still in flux.