### PR TITLE
Add a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+#
+# Exclude these files from release archives.
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+# If you develop for this repo using Composer, use `--prefer-source`.
+# https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
+# https://blog.madewithlove.be/post/gitattributes/
+#
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/appveyor.yml export-ignore
+/box.json export-ignore
+/phpcs.xml.dist export-ignore
+/phpcs-ruleset.xml export-ignore
+/tests export-ignore
+
+#
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+#
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+*.md text
+*.php text


### PR DESCRIPTION
This is the same PR as previously pulled in PR JakubOnderka/PHP-Parallel-Lint#144

This makes the release zips used by Packagist smaller as it doesn't ship the test or config files which end-users shouldn't need anyway.

Fixes #11