### PR TITLE
Ignore PHP startup errors

### DIFF
--- a/src/Process/PhpProcess.php
+++ b/src/Process/PhpProcess.php
@@ -23,8 +23,11 @@ class PhpProcess extends Process
      */
     private function constructParameters(array $parameters, $isHhvm)
     {
+        // Always ignore PHP startup errors ("Unable to load library...") in sub-processes.
+        array_unshift($parameters, '-d display_startup_errors=0');
+
         if ($isHhvm) {
-            $parameters = array_merge(array('-php'), $parameters);
+            array_unshift($parameters, '-php');
         }
 
         return $parameters;


### PR DESCRIPTION
Ignoring PHP startup errors completely for any PHP processes started from within the application.

Fixes #33