### PR TITLE
Provide one true way to run the test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - composer install --no-interaction --prefer-source
 
 script:
-  - ./vendor/bin/tester -p php tests
+  - composer test
   - ./parallel-lint --exclude vendor --exclude tests/examples --no-colors .
   - ./parallel-lint --exclude vendor --exclude tests/examples .
   - if [[ "$SNIFF" == "1" ]]; then ./vendor/bin/phpcs;fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,6 @@ install:
   - php composer.phar install --prefer-source --no-interaction
 
 test_script:
-  - vendor\bin\tester tests -p php
+  - php composer.phar test
   - php parallel-lint --exclude vendor --exclude tests\examples --no-colors .
   - php parallel-lint --exclude vendor --exclude tests\examples .

--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,11 @@
     },
     "bin": [
         "parallel-lint"
-    ]
+    ],
+    "scripts": {
+        "test": "@php vendor/bin/tester -p php tests"
+    },
+    "scripts-descriptions": {
+        "test": "Run all tests!"
+    }
 }


### PR DESCRIPTION
I checked out the project and it wasn't clear to me how to run the tests (as its not using phpunit). After searching around I found two variations of how to run the tests.

Adding a `scripts` entry to composer provides a single definition on how to run the tests, usable for every one; also locally:
```
$ composer tests
> tester -p php tests
 _____ ___  ___ _____ ___  ___
|_   _/ __)( __/_   _/ __)| _ )
  |_| \___ /___) |_| \___ |_|_\  v2.3.2

Note: No php.ini is used.
PHP 7.4.7 (cli) | php -n | 8 threads

.........................


OK (25 tests, 1.4 seconds)
```
After that I adapted the existing ones to use the one from composer.

Thanks!