### PR TITLE
Travis: add build against PHP 8.0 and fix failing test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
     - php: 7.3
     - php: 7.4
       env: SNIFF=1
+    - php: 8.0
     - php: "nightly"
 
   fast_finish: true

--- a/tests/ParallelLint.lint.phpt
+++ b/tests/ParallelLint.lint.phpt
@@ -101,8 +101,8 @@ class ParallelLintLintTest extends Tester\TestCase
         Assert::false($result->hasSyntaxError());
         Assert::equal(0, count($result->getErrors()));
 
-        if (PHP_VERSION_ID < 70000) {
-            Tester\Environment::skip('test for php version > 7.0');
+        if (PHP_VERSION_ID < 70000 || PHP_VERSION_ID >= 80000 ) {
+            Tester\Environment::skip('test for php version 7.0-7.4');
         }
 
         $parallelLint = new ParallelLint($this->getPhpExecutable());


### PR DESCRIPTION
### Travis: add build against PHP 8.0

PHP 8.0 has been branched off two months ago, so `nightly` is now PHP 8.1 and in the mean time PHP 8.0 was released last week.

As of today, there is a PHP 8.0 image available on Travis.

This PR adds a new build against PHP 8.0 to the matrix and, as PHP 8.0 has been released, that build is not allowed to fail.

### ParallelLintLintTest::testDeprecated(): fix the test

I previously pointed out in #5 that this test was failing, but clearly no action has been taken on that in the mean time. Either way, fixing this now.

This test is expected to throw a deprecation warning for the PHP4-style class constructor (method named the same as the class).

In PHP 8, the deprecation warning is no longer thrown and PHP4-style constructor method are now treated as _normal_ methods.

This fixes the test to have the correct expectations.

