### PR TITLE
GitHub Actions for testing, and automatic phar creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+name: Build and test phar
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  bundle:
+    name: Bundle binary
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 5.4
+          extensions: exif, phar, openssl
+          coverage: false
+          ini-values: phar.readonly=Off
+
+      - name: Install Box from GitHub
+        run: |
+          curl -LSs https://box-project.github.io/box2/installer.php | php
+          test -f ./box.phar
+          test -d ~/bin || mkdir ~/bin
+          mv ./box.phar ~/bin/box
+          ~/bin/box -V
+          echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v1
+
+      - name: Building binary...
+        run: box build -v
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: parallel-lint-phar
+          path: ./parallel-lint.phar
+
+  verify:
+    name: Validate binary on PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental == true }}
+    needs:
+      - bundle
+
+    strategy:
+      matrix:
+        php:
+          - '5.4'
+          - '5.5'
+          - '5.6'
+          - '7.0'
+          - '7.1'
+          - '7.2'
+          - '7.3'
+          - '7.4'
+          - '8.0'
+          - '8.1'
+
+        include:
+          - php: '8.1'
+            experimental: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: parallel-lint-phar
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: false
+
+      - name: Run linter against codebase
+        run: php ./parallel-lint.phar src/
+
+  publish:
+    name: Add binary to release
+    runs-on: ubuntu-latest
+    needs:
+      - bundle
+      - verify
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: parallel-lint-phar
+
+      - name: Draft Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: false
+
+      - name: Upload Phar as Release Asset
+        id: upload-release-asset
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: parallel-lint.phar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,128 @@
+name: Run unit and style tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - master
+
+jobs:
+  lint:
+    name: Run style linter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          extensions: json
+          coverage: none
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v1
+
+      - name: Run code sniffer
+        run: vendor/bin/phpcs
+
+  test:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          extensions: json
+          coverage: none
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v1
+
+      - name: Run tests
+        run: composer test
+
+  bundle:
+    name: Bundle binary
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 5.4
+          extensions: exif, phar, openssl
+          coverage: false
+          ini-values: phar.readonly=Off
+
+      - name: Install Box from GitHub
+        run: |
+          curl -LSs https://box-project.github.io/box2/installer.php | php
+          test -f ./box.phar
+          test -d ~/bin || mkdir ~/bin
+          mv ./box.phar ~/bin/box
+          ~/bin/box -V
+          echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v1
+
+      - name: Building binary...
+        run: box build -v
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: parallel-lint-phar
+          path: ./parallel-lint.phar
+
+  verify-bundle:
+    name: Validate binary on PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental == true }}
+    needs:
+      - bundle
+
+    strategy:
+      matrix:
+        php:
+          - '5.4'
+          - '5.5'
+          - '5.6'
+          - '7.0'
+          - '7.1'
+          - '7.2'
+          - '7.3'
+          - '7.4'
+          - '8.0'
+          - '8.1'
+
+        include:
+          - php: '8.1'
+            experimental: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: parallel-lint-phar
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: false
+
+      - name: Run linter against codebase
+        run: php ./parallel-lint.phar src/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,8 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
-          extensions: json
-          coverage: none
+          php-version: 5.4
+          extensions: json, tokenizer
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/box.json
+++ b/box.json
@@ -5,7 +5,7 @@
         "Herrera\\Box\\Compactor\\Php"
     ],
     "extract": false,
-    "main": "parallel-lint.php",
+    "main": "parallel-lint",
     "files": [
         "LICENSE"
     ],


### PR DESCRIPTION
Depends on #45, test results are available at [roelofr:#1](https://github.com/roelofr/php-parallel-lint/pull/1), which merge into that master branch.

I'm still seeing errors on this branch, very wierd ones at that:

```
Fatal error: Interface 'JsonSerializable' not found in /home/runner/work/php-parallel-lint/php-parallel-lint/src/Error.php on line 4
```

I don't know why, but the Json class seems unavailable, although the json extension is enabled. 

On PHP 8.0 I even saw `Fatal error: Uncaught Error: Call to undefined function token_get_all()`, which is a built-in and should always work.

Some wierd stuff going on here... :thinking: 

Will close #44.

