### PR TITLE
Determine skip lint process failure by status code instead of stderr content

### DIFF
--- a/src/ParallelLint.php
+++ b/src/ParallelLint.php
@@ -115,7 +115,7 @@ class ParallelLint
         if (!empty($waiting)) {
             $skipLintProcess->waitForFinish();
 
-            if ($skipLintProcess->getErrorOutput()) {
+            if ($skipLintProcess->isFail()) {
                 $message = "Error in skip-linting.php process\nError output: {$skipLintProcess->getErrorOutput()}";
                 throw new \Exception($message);
             }


### PR DESCRIPTION
Fix linter crashing with Xdebug 3 on without listening client - more detailed description in linked issue.

Fixes #47