### PR TITLE
Only use PHP_BINARY if it is not an empty string

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -128,7 +128,7 @@ class Settings
         $settings = new self;
 
         // Use the currently invoked php as the default if possible
-        if (defined('PHP_BINARY')) {
+        if (defined('PHP_BINARY') && PHP_BINARY !== '') {
             $settings->phpExecutable = PHP_BINARY;
         }
 


### PR DESCRIPTION
Apparently PHP_BINARY can sometimes be an empty string.
If this is the case, we don't want to use it.
Doing so results in `Unable to execute ''.`

A reproduction example for when this happens is included below:
 - Create both files
 - chmod +x repro2.php
 - php repro.php
 - You'll see that `PHP_BINARY` is "".

If you run repro2.php directly you'll likely then see it with a correct path

repro.php:
```php
<?php

$descriptorspec = array(
	0 => array("pipe", "r"),   // stdin is a pipe that the child will read from
	1 => array("pipe", "w"),   // stdout is a pipe that the child will write to
	2 => array("pipe", "w")    // stderr is a pipe that the child will write to
);
flush();
$process = proc_open(__DIR__ . '/repro2.php', $descriptorspec, $pipes, __DIR__, array());
if (is_resource($process)) {
	while ( ( $c = fgetc($pipes[1]) ) !== false ) {
		echo $c;
		flush();
	}
}
echo proc_get_status($process)['exitcode'];
```

repro2.php:
```sh
#!/usr/bin/env php
<?php

var_dump(PHP_BINARY);
```

I discovered this while trying to upgrade https://github.com/addwiki/addwiki from the old `jakub-onderka/php-parallel-lint` package to `"php-parallel-lint/php-parallel-lint": "^1.2"`.
This is a monorepo, and there is a convenience script for running things such as linters in all sub packages.
This makes use of `proc_open` which seems to have something to do with this issue.