### PR TITLE
Extend by the Code Climate output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ It is strongly recommended for existing users of the (unmaintained)
 - `--no-progress`   		Disable progress in console output.
 - `--checkstyle`    		Output results as Checkstyle XML.
 - `--json`          		Output results as JSON string (requires PHP 5.4).
+- `--gitlab`          		Output results for the GitLab Code Quality widget (requires PHP 5.4), see more in [Code Quality](https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html) documentation.
 - `--blame`         		Try to show git blame for row with error.
 - `--git <git>`     		Path to Git executable to show blame message (default: 'git').
 - `--stdin`         		Load files and folder to test from standard input.

--- a/src/Application.php
+++ b/src/Application.php
@@ -87,6 +87,7 @@ Options:
     --no-colors             Disable colors in console output.
     --no-progress           Disable progress in console output.
     --json                  Output results as JSON string.
+    --gitlab                Output results for the GitLab Code Quality Widget.
     --checkstyle            Output results as Checkstyle XML.
     --blame                 Try to show git blame for row with error.
     --git <git>             Path to Git executable to show blame message (default: 'git').

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -82,6 +82,8 @@ class Manager
         switch ($settings->format) {
             case Settings::FORMAT_JSON:
                 return new JsonOutput($writer);
+            case Settings::FORMAT_GITLAB:
+                return new GitLabOutput($writer);
             case Settings::FORMAT_CHECKSTYLE:
                 return new CheckstyleOutput($writer);
         }

--- a/src/Output.php
+++ b/src/Output.php
@@ -85,6 +85,81 @@ class JsonOutput implements Output
     }
 }
 
+class GitLabOutput implements Output
+{
+    /** @var IWriter */
+    protected $writer;
+
+    /**
+     * @param IWriter $writer
+     */
+    public function __construct(IWriter $writer)
+    {
+        $this->writer = $writer;
+    }
+
+    public function ok()
+    {
+
+    }
+
+    public function skip()
+    {
+
+    }
+
+    public function error()
+    {
+
+    }
+
+    public function fail()
+    {
+
+    }
+
+    public function setTotalFileCount($count)
+    {
+
+    }
+
+    public function writeHeader($phpVersion, $parallelJobs, $hhvmVersion = null)
+    {
+
+    }
+
+    public function writeResult(Result $result, ErrorFormatter $errorFormatter, $ignoreFails)
+    {
+        $errors = array();
+        foreach ($result->getErrors() as $error) {
+            $message = $error->getMessage();
+            $line = 1;
+            if ($error instanceof SyntaxError) {
+                $line = $error->getLine();
+            }
+            $filePath = $error->getFilePath();
+            $result = array(
+                'type' => 'issue',
+                'check_name' => 'Parse error',
+                'description' => $message,
+                'categories' => 'Style',
+                'fingerprint' => md5($filePath . $message . $line),
+                'severity' => 'minor',
+                'location' => array(
+                    'path' => $filePath,
+                    'lines' => array(
+                        'begin' => $line,
+                    ),
+                ),
+            );
+            array_push($errors, $result);
+        }
+
+        $string = json_encode($errors) . PHP_EOL;
+        $this->writer->write($string);
+    }
+}
+
 class TextOutput implements Output
 {
     const TYPE_DEFAULT = 'default',

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -13,6 +13,7 @@ class Settings
 
     const FORMAT_TEXT = 'text';
     const FORMAT_JSON = 'json';
+    const FORMAT_GITLAB = 'gitlab';
     const FORMAT_CHECKSTYLE = 'checkstyle';
 
     /**
@@ -177,6 +178,10 @@ class Settings
 
                     case '--json':
                         $settings->format = self::FORMAT_JSON;
+                        break;
+
+                    case '--gitlab':
+                        $settings->format = self::FORMAT_GITLAB;
                         break;
 
                     case '--checkstyle':

--- a/tests/Output.phpt
+++ b/tests/Output.phpt
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * @testCase
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use JakubOnderka\PhpParallelLint\ErrorFormatter;
+use JakubOnderka\PhpParallelLint\GitLabOutput;
+use JakubOnderka\PhpParallelLint\IWriter;
+use JakubOnderka\PhpParallelLint\Result;
+use JakubOnderka\PhpParallelLint\SyntaxError;
+use Tester\Assert;
+
+class OutputTest extends Tester\TestCase
+{
+    /**
+     * @dataProvider getGitLabOutputData
+     */
+    public function testGitLabOutput($errors)
+    {
+        $result = new Result($errors, array(), array(), 0);
+        $writer = new TestWriter();
+        $output = new GitLabOutput($writer);
+
+        $output->writeResult($result, new ErrorFormatter(), true);
+
+        $result = (array) json_decode($writer->getLogs());
+
+        for ($i = 0; $i < count($result) && $i < count($errors); $i++) {
+            $message = $errors[$i]->getMessage();
+            $filePath = $errors[$i]->getFilePath();
+            $line = 1;
+            if ($errors[$i] instanceof SyntaxError) {
+                $line = $errors[$i]->getLine();
+            }
+            Assert::equal($result[$i]->type, 'issue');
+            Assert::equal($result[$i]->check_name, 'Parse error');
+            Assert::equal($result[$i]->categories, 'Style');
+            Assert::equal($result[$i]->severity, 'minor');
+            Assert::equal($result[$i]->description, $message);
+            Assert::equal($result[$i]->fingerprint, md5($filePath . $message . $line));
+            Assert::equal($result[$i]->location->path, $filePath);
+            Assert::equal($result[$i]->location->lines->begin, $line);
+        }
+    }
+
+    public function getGitLabOutputData()
+    {
+        return array(
+            array(
+                'errors' => array()
+            ),
+            array(
+                'errors' => array(
+                    new SyntaxError('foo/bar.php', "Parse error: syntax error, unexpected in foo/bar.php on line 52")
+                )
+            ),
+            array(
+                'errors' => array(
+                    new JakubOnderka\PhpParallelLint\Error('foo/bar.php', "PHP Parse error: syntax error, unexpected ';'")
+                )
+            ),
+            array(
+                'errors' => array(
+                    new SyntaxError('foo/bar.php', "Parse error: syntax error, unexpected in foo/bar.php on line 52"),
+                    new JakubOnderka\PhpParallelLint\Error('foo/bar.php', "PHP Parse error: syntax error, unexpected ';'")
+                )
+            ),
+        );
+    }
+}
+
+class TestWriter implements IWriter
+{
+    /** @var string */
+    protected $logs = "";
+
+    /**
+     * @param string $string
+     */
+    public function write($string)
+    {
+        $this->logs .= $string;
+    }
+
+    public function getLogs()
+    {
+        return $this->logs;
+    }
+}
+
+$testCase = new OutputTest;
+$testCase->run();

--- a/tests/Settings.parseArguments.phpt
+++ b/tests/Settings.parseArguments.phpt
@@ -103,6 +103,14 @@ class SettingsParseArgumentsTest extends Tester\TestCase
         Assert::equal(Settings::FORMAT_JSON, $settings->format);
     }
 
+    public function testGitLabOutput()
+    {
+        $commandLine = './parallel-lint --gitlab .';
+        $argv = explode(" ", $commandLine);
+        $settings = Settings::parseArguments($argv);
+        Assert::equal(Settings::FORMAT_GITLAB, $settings->format);
+    }
+
     public function testCheckstyleOutput()
     {
         $commandLine = './parallel-lint --checkstyle .';


### PR DESCRIPTION
Hi, we use this linter in our PHP projects. We have our repositories in GitLab and use the CI pipeline there. When we run the CI pipeline, we run QA tools. When the pipeline is executed, we want GitLab to load the errors from a json file and display them in the merge request. This should make it easier to see which bugs have been added and which have been fixed.

For this we use the [Code Quality](https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html#implementing-a-custom-tool) widget. This requires creating a Json file that implements a subset of the code-climate specification. 

With this merge request I suggest that this linter supports this format so that not every CI pipeline has to use a converter.

We also use PHPStan, they support this [format](https://github.com/phpstan/phpstan/blob/master/website/src/user-guide/output-format.md). 

PHP_CodeSniffer do not support the format, but they offer the possibility to include external [reports/formats](https://github.com/lukas9393/PHP_CodeSniffer/commit/77f77c69c42af17a564fedf707937fef32a754d4). I have not discovered this possibility in this linter. We strongly want to avoid using a fork for this feature, so I made this merge request.

Sorry for bothering you with this issue.