### PR TITLE
Bug fix: make Phar file run independently of project under scan

### DIFF
--- a/parallel-lint
+++ b/parallel-lint
@@ -44,6 +44,13 @@ $autoloadLocations = array(
     __DIR__ . '/../../autoload.php',
 );
 
+if (class_exists('Phar') && Phar::running() !== '') {
+    // Running from a phar file. Prevent loading - potentially blocking - project autoload file.
+    $autoloadLocations = array(
+        __DIR__ . '/vendor/autoload.php',
+    );
+}
+
 $loaded = false;
 foreach ($autoloadLocations as $autoload) {
     if (is_file($autoload)) {


### PR DESCRIPTION
This prevents the autoload finder from attempting to load the Composer `autoload.php` file of the project under scan when Parallel Lint is being run from a Phar file.

Fixes #61