### PR TITLE
PHP 8.1: silence the deprecation notices about missing return types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "nette/tester": "^1.3 || ^2.0",
         "php-parallel-lint/php-console-highlighter": "~0.3",
-        "squizlabs/php_codesniffer": "^3.5"
+        "squizlabs/php_codesniffer": "^3.6"
     },
     "suggest": {
         "php-parallel-lint/php-console-highlighter": "Highlight syntax in code snippet"

--- a/src/Error.php
+++ b/src/Error.php
@@ -1,6 +1,8 @@
 <?php
 namespace JakubOnderka\PhpParallelLint;
 
+use ReturnTypeWillChange;
+
 class Error implements \JsonSerializable
 {
     /** @var string */
@@ -57,6 +59,7 @@ class Error implements \JsonSerializable
      * @return mixed data which can be serialized by <b>json_encode</b>,
      * which is a value of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array(
@@ -87,6 +90,7 @@ class Blame implements \JsonSerializable
      * @return mixed data which can be serialized by <b>json_encode</b>,
      * which is a value of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     function jsonSerialize()
     {
         return array(

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -4,6 +4,7 @@ namespace JakubOnderka\PhpParallelLint;
 use JakubOnderka\PhpParallelLint\Contracts\SyntaxErrorCallback;
 use JakubOnderka\PhpParallelLint\Process\GitBlameProcess;
 use JakubOnderka\PhpParallelLint\Process\PhpExecutable;
+use ReturnTypeWillChange;
 
 class Manager
 {
@@ -226,6 +227,7 @@ class RecursiveDirectoryFilterIterator extends \RecursiveFilterIterator
      * @link http://php.net/manual/en/filteriterator.accept.php
      * @return bool true if the current element is acceptable, otherwise false.
      */
+    #[ReturnTypeWillChange]
     public function accept()
     {
         $current = $this->current()->getPathname();
@@ -245,6 +247,7 @@ class RecursiveDirectoryFilterIterator extends \RecursiveFilterIterator
      * @link http://php.net/manual/en/recursivefilteriterator.haschildren.php
      * @return bool true if the inner iterator has children, otherwise false
      */
+    #[ReturnTypeWillChange]
     public function hasChildren()
     {
         return $this->iterator->hasChildren();
@@ -257,6 +260,7 @@ class RecursiveDirectoryFilterIterator extends \RecursiveFilterIterator
      * @link http://php.net/manual/en/recursivefilteriterator.getchildren.php
      * @return \RecursiveFilterIterator containing the inner iterator's children.
      */
+    #[ReturnTypeWillChange]
     public function getChildren()
     {
         return new self($this->iterator->getChildren(), $this->excluded);

--- a/src/Result.php
+++ b/src/Result.php
@@ -1,6 +1,8 @@
 <?php
 namespace JakubOnderka\PhpParallelLint;
 
+use ReturnTypeWillChange;
+
 class Result implements \JsonSerializable
 {
     /** @var Error[] */
@@ -154,6 +156,7 @@ class Result implements \JsonSerializable
      * @return mixed data which can be serialized by <b>json_encode</b>,
      * which is a value of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     function jsonSerialize()
     {
         return array(

--- a/src/exceptions.php
+++ b/src/exceptions.php
@@ -1,8 +1,11 @@
 <?php
 namespace JakubOnderka\PhpParallelLint;
 
+use ReturnTypeWillChange;
+
 class Exception extends \Exception implements \JsonSerializable
 {
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array(


### PR DESCRIPTION
### PHP 8.1: silence the deprecation notice about jsonSerialize() return type

As of PHP 8.1, PHP adds return type declarations to the PHP native functions.

For the `JsonSerializable::jsonSerialize()` interface method, the new signature is:
```php
function jsonSerialize(): mixed {}
```

As this libary still supports PHP 5.3, it is not possible to add this return type as:
1. Return types weren't available until PHP 7.0 and
2. the `mixed` return type only became available in PHP 8.0.

For libraries supporting PHP 7.0+, it would have been possible to fix this by adding an `array` return type (higher specificity).

For libraries still supporting PHP < 7.0, there are two choices:
1. Either decouple from the `JsonSerialize` interface.
2. Or use a PHP 8.1 attribute to silence the deprecation notice.

As prior to PHP 8.0, attributes are ignored as if they were comments, it is safe to add the attribute to the library and IMO, this is prefered over decoupling the classes from the `JsonSerializable` interface.

To prevent PHPCS tripping up over "something" existing between the function docblock and the declaration, PHPCS 3.6.0 should be used, which is the first PHPCS version with full PHP 8.0 syntax support in the sniffs (albeit that there are still some small things to fix up in PHPCS).

Refs:
* https://wiki.php.net/rfc/internal_method_return_types
* https://github.com/php/php-src/pull/7051

### PHP 8.1: silence the deprecation notice about RecursiveFilterIterator method return types

As of PHP 8.1, PHP adds return type declarations to the PHP native functions.

For the `RecursiveFilterIterator`, the relevant method signatures are:
* `accept(): bool`
* `hasChildren(): bool`
* `getChildren(): ?RecursiveFilterIterator`

As this libary still supports PHP 5.3, it is not possible to add this return type as:
1. Return types weren't available until PHP 7.0 and
2. the `mixed` return type only became available in PHP 8.0.

For libraries still supporting PHP < 7.0, there are two choices:
1. Either decouple from the interface.
2. Or use a PHP 8.1 attribute to silence the deprecation notice.

As prior to PHP 8.0, attributes are ignored as if they were comments, it is safe to add the attribute to the library and IMO, this is prefered over decoupling the classes from the interface.

To prevent PHPCS tripping up over "something" existing between the function docblock and the declaration, PHPCS 3.6.0 should be used, which is the first PHPCS version with full PHP 8.0 syntax support in the sniffs (albeit that there are still some small things to fix up in PHPCS).

Refs:
* https://wiki.php.net/rfc/internal_method_return_types