### PR TITLE
GH Actions: set error reporting to E_ALL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           php-version: 5.4
           extensions: exif, phar, openssl
           coverage: none
-          ini-values: phar.readonly=Off
+          ini-values: phar.readonly=Off, error_reporting=E_ALL, display_errors=On
 
       - name: Install Box from GitHub
         run: |
@@ -106,6 +106,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          ini-values: error_reporting=E_ALL, display_errors=On
           coverage: none
 
       # Remove PHPCS as it has a minimum PHP requirements of PHP 5.4 and would block install on PHP 5.3.


### PR DESCRIPTION
Turns out the default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `E_ALL` and `display_errors=On` to ensure **all** PHP notices are shown.

_Note: as the CI run isn't failing on the deprecation notice as addressed in #64, this PR exposes a shortage of tests, which should be addressed, though this is outside the scope of this PR._