### PR TITLE
Add error severity levels

### DIFF
--- a/src/Error.php
+++ b/src/Error.php
@@ -11,14 +11,18 @@ class Error implements \JsonSerializable
     /** @var string */
     protected $message;
 
+    /** @var string */
+    protected $severity;
+
     /**
      * @param string $filePath
      * @param string $message
      */
-    public function __construct($filePath, $message)
+    public function __construct($filePath, $message, $severity = 'error')
     {
         $this->filePath = $filePath;
         $this->message = rtrim($message);
+        $this->severity = $severity;
     }
 
     /**
@@ -27,6 +31,14 @@ class Error implements \JsonSerializable
     public function getMessage()
     {
         return $this->message;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSeverity()
+    {
+        return $this->severity;
     }
 
     /**
@@ -63,7 +75,7 @@ class Error implements \JsonSerializable
     public function jsonSerialize()
     {
         return array(
-            'type' => 'error',
+            'type' => $this->getSeverity(),
             'file' => $this->getFilePath(),
             'message' => $this->getMessage(),
         );
@@ -221,6 +233,7 @@ class SyntaxError extends Error
             'message' => $this->getMessage(),
             'normalizeMessage' => $this->getNormalizedMessage(),
             'blame' => $this->blame,
+            'severity' => $this->getSeverity(),
         );
     }
 }

--- a/src/Output.php
+++ b/src/Output.php
@@ -422,15 +422,18 @@ class CheckstyleOutput implements Output
             if ($error instanceof SyntaxError) {
                 $line = $error->getLine();
                 $source = "Syntax Error";
+                $severity = $error->getSeverity();
             } else {
                 $line = 1;
                 $source = "Linter Error";
+                $severity = 'error';
             }
 
             $errors[$error->getShortFilePath()][] = array(
                 'message' => $message,
                 'line' => $line,
-                'source' => $source
+                'source' => $source,
+                'severity' => $severity,
             );
         }
 
@@ -439,8 +442,9 @@ class CheckstyleOutput implements Output
             foreach ($fileErrors as $fileError) {
                 $this->writer->write(
                     sprintf(
-                        '        <error line="%d" severity="ERROR" message="%s" source="%s" />',
+                        '        <error line="%d" severity="%s" message="%s" source="%s" />',
                         $fileError['line'],
+                        $fileError['severity'],
                         $fileError['message'],
                         $fileError['source']
                     ) .

--- a/src/ParallelLint.php
+++ b/src/ParallelLint.php
@@ -96,7 +96,7 @@ class ParallelLint
 
                     } else if ($process->containsError()) {
                         $checkedFiles[] = $file;
-                        $errors[] = $this->triggerSyntaxErrorCallback(new SyntaxError($file, $process->getSyntaxError()));
+                        $errors[] = $this->triggerSyntaxErrorCallback(new SyntaxError($file, $process->getSyntaxError(), $process->getSeverity()));
                         $processCallback(self::STATUS_ERROR, $file);
 
                     } else if ($process->isSuccess()) {
@@ -135,7 +135,7 @@ class ParallelLint
 
                 } else if ($process->containsError()) {
                     $checkedFiles[] = $file;
-                    $errors[] = $this->triggerSyntaxErrorCallback(new SyntaxError($file, $process->getSyntaxError()));
+                    $errors[] = $this->triggerSyntaxErrorCallback(new SyntaxError($file, $process->getSyntaxError(), $process->getSeverity()));
                     $processCallback(self::STATUS_ERROR, $file);
 
                 } else {

--- a/src/Process/LintProcess.php
+++ b/src/Process/LintProcess.php
@@ -15,6 +15,11 @@ class LintProcess extends PhpProcess
     private $showDeprecatedErrors;
 
     /**
+     * @var string
+     */
+    protected $severity;
+
+    /**
      * @param PhpExecutable $phpExecutable
      * @param string $fileToCheck Path to file to check
      * @param bool $aspTags
@@ -62,6 +67,7 @@ class LintProcess extends PhpProcess
             // Look for fatal errors first
             foreach (explode("\n", $this->getOutput()) as $line) {
                 if ($this->containsFatalError($line)) {
+                    $this->severity = 'error';
                     return $line;
                 }
             }
@@ -69,6 +75,7 @@ class LintProcess extends PhpProcess
             // Look for parser errors second
             foreach (explode("\n", $this->getOutput()) as $line) {
                 if ($this->containsParserError($line)) {
+                    $this->severity = 'error';
                     return $line;
                 }
             }
@@ -76,6 +83,7 @@ class LintProcess extends PhpProcess
             // Look for deprecated errors third
             foreach (explode("\n", $this->getOutput()) as $line) {
                 if ($this->containsDeprecatedError($line)) {
+                    $this->severity = 'warning';
                     return $line;
                 }
             }
@@ -84,6 +92,19 @@ class LintProcess extends PhpProcess
         }
 
         return false;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSeverity()
+    {
+        if (!empty($this->severity)) {
+            return $this->severity;
+        } else {
+            $error = $this->getSyntaxError();
+            return '$this->severity';
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds severity levels to the `Error` ckass, making it possible to distinguish between syntax/fatal errors and deprecation notices. It also fixes an error in the checkstyle output which had the `severity` attribute capitalized (closes #67)