### PR TITLE
[Hotfix] Fix Phar building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.3
+          php-version: 8.0
           extensions: exif, phar, openssl
           coverage: none
           ini-values: phar.readonly=Off

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,27 +19,27 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 5.4
+          php-version: 7.3
           extensions: exif, phar, openssl
           coverage: none
           ini-values: phar.readonly=Off
-
-      - name: Install Box from GitHub
-        run: |
-          curl -LSs https://box-project.github.io/box2/installer.php | php
-          test -f ./box.phar
-          test -d ~/bin || mkdir ~/bin
-          mv ./box.phar ~/bin/box
-          ~/bin/box -V
-          echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v1
         with:
           composer-options: "--no-dev"
 
+      - name: Install Box
+        run: wget https://github.com/humbug/box/releases/latest/download/box.phar -O box.phar && chmod 0755 box.phar && pwd
+
+      - name: Validate configuration
+        run: php box.phar validate -i box.json
+
       - name: Building binary...
-        run: box build -v
+        run: php box.phar compile -v --config=box.json
+
+      - name: Show info about the build phar with humbug/box
+        run: php box.phar info -l parallel-lint.phar
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,27 +45,27 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 5.4
+          php-version: 7.3
           extensions: exif, phar, openssl
           coverage: none
           ini-values: phar.readonly=Off, error_reporting=E_ALL, display_errors=On
-
-      - name: Install Box from GitHub
-        run: |
-          curl -LSs https://box-project.github.io/box2/installer.php | php
-          test -f ./box.phar
-          test -d ~/bin || mkdir ~/bin
-          mv ./box.phar ~/bin/box
-          ~/bin/box -V
-          echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v1
         with:
           composer-options: "--no-dev"
 
+      - name: Install Box
+        run: wget https://github.com/humbug/box/releases/latest/download/box.phar -O box.phar && chmod 0755 box.phar && pwd
+
+      - name: Validate configuration
+        run: php box.phar validate -i box.json
+
       - name: Building binary...
-        run: box build -v
+        run: php box.phar compile -v --config=box.json
+
+      - name: Show info about the build phar with humbug/box
+        run: php box.phar info -l parallel-lint.phar
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.3
+          php-version: 8.0
           extensions: exif, phar, openssl
           coverage: none
           ini-values: phar.readonly=Off, error_reporting=E_ALL, display_errors=On

--- a/box.json
+++ b/box.json
@@ -1,11 +1,15 @@
 {
+    "base-path": null,
     "output": "parallel-lint.phar",
     "chmod": "0755",
     "compactors": [
-        "Herrera\\Box\\Compactor\\Php"
+        "KevinGH\\Box\\Compactor\\Php"
     ],
-    "extract": false,
     "main": "parallel-lint",
+    "directories": [
+        "bin",
+        "src"
+    ],
     "files": [
         "LICENSE"
     ],
@@ -14,15 +18,7 @@
             "name": ["*.php"],
             "exclude": ["Tests", "tests"],
             "in": "vendor"
-        },
-        {
-            "exclude": ["Tests"],
-            "in": "src"
-        },
-        {
-            "in": "bin"
         }
     ],
-    "stub": true,
-    "web": false
+    "stub": true
 }

--- a/box.json
+++ b/box.json
@@ -2,6 +2,7 @@
     "base-path": null,
     "output": "parallel-lint.phar",
     "chmod": "0755",
+    "check-requirements": false,
     "compactors": [
         "KevinGH\\Box\\Compactor\\Php"
     ],


### PR DESCRIPTION
### Upgrade to Box 3 for Phar generation

Box 2 is no longer maintained and will not be made compatible with more recent PHP versions.

Refs:
* https://github.com/box-project/box/blob/master/UPGRADE.md#from-27-to-30
* https://github.com/box-project/box/blob/master/doc/configuration.md

### PHP 8.1: fix Phar building

For the time being, until box-project/box#567 has been fixed:
1. Disable the addition of the requirement checker from Box as the version included in the last release of Box is not compatible with PHP 8.1.
2. Change the PHP version used to generate the Phar to PHP 8.0 to get round the problem the PHP compactor has with attributes.
    Note: the generated Phar file should still be compatible with all supported PHP versions.

Fixes #69
Closes #39 
Closes #36

@grogy A release with a Phar generated after this fix has been merged would be appreciated as anyone currently using this tool to lint their files against PHP 8.1 (in CI or otherwise) is affected by this issue.