### PR TITLE
GH Actions: fix failing tests on PHP 5.3-5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     ],
     "scripts": {
         "test": "@php vendor/bin/tester -C -p php tests",
-        "testphp5": "@php vendor/bin/tester -p php tests"
+        "testphp5": "@php vendor/bin/tester -c tests/php5.3-5.5.ini -p php tests"
     },
     "scripts-descriptions": {
         "test": "Run all tests!"

--- a/tests/php5.3-5.5.ini
+++ b/tests/php5.3-5.5.ini
@@ -1,0 +1,10 @@
+[PHP]
+
+extension=json.so
+extension=tokenizer.so
+
+memory_limit=512M
+
+error_reporting=-1
+display_errors=On
+display_startup_errors = On


### PR DESCRIPTION
I still can't fathom why the tests were previously passing and are failing now. I know they were running fine before as I checked the logs on multiple occasions.

I've now [unearthed the documentation from Nette Tester 1.x](https://web.archive.org/web/20170602082733/https://tester.nette.org/#toc-how-the-tester-runs) which what's used to run the tests on PHP 5.3-5.5.
The docs state:
> The Tester runs PHP processes with `-n` option, so without `php.ini`. More details in the [Own php.ini chapter](https://web.archive.org/web/20170602082733/https://tester.nette.org/#toc-own-php-ini).

... which in a way is similar to the problem we previously ran into for Nette Tester 2.x, which is why the `-C` (= Use system-wide `php.ini`) option is used there. Also see https://github.com/php-parallel-lint/PHP-Parallel-Lint/pull/55

As the tests were running and passing on Nette 1.x/PHP 5.3 - 5.5 previously, we never dug in deeper for the peculiarities of Nette 1.x.

So to fix the test runs against PHP 5.3 - 5.5, which are using Nette Tester 1.x, I'm proposing to add a `php.ini` file to the `tests` directory specifically for use with PHP 5.3 - 5.5.

This should get the tests passing again.

I'm adding @villfa as co-author to this PR as I ended up with this solution inspired by [a PR they pulled to my fork of this repo](https://github.com/jrfnl/PHP-Parallel-Lint/pull/1).