### PR TITLE
GH Actions: various improvements to the workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bundle:
     # Don't run on forks.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           php-version: 8.0
           extensions: exif, phar, openssl
           coverage: none
-          ini-values: phar.readonly=Off
+          ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, zend.assertions=1
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v1
@@ -84,6 +84,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          ini-values: error_reporting=-1, display_errors=On, zend.assertions=1
           coverage: none
 
       - name: Run linter against codebase

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
   verify:
     name: Validate binary on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental == true }}
+    continue-on-error: ${{ matrix.php == '8.2' }}
     needs:
       - bundle
 
@@ -67,10 +67,6 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
-
-        include:
-          - php: '8.2'
-            experimental: true
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   bundle:
+    # Don't run on forks.
+    if: github.repository == 'php-parallel-lint/PHP-Parallel-Lint'
+
     name: Bundle binary
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           php-version: 8.0
           extensions: exif, phar, openssl
           coverage: none
-          ini-values: phar.readonly=Off, error_reporting=E_ALL, display_errors=On
+          ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, zend.assertions=1
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v1
@@ -107,7 +107,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: error_reporting=E_ALL, display_errors=On
+          ini-values: error_reporting=-1, display_errors=On, zend.assertions=1
           coverage: none
 
       # Remove PHPCS as it has a minimum PHP requirements of PHP 5.4 and would block install on PHP 5.3.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Run style linter

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
   test:
     name: Run tests on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental == true }}
+    continue-on-error: ${{ matrix.php == '8.2' }}
     needs:
       - bundle
 
@@ -94,10 +94,6 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
-
-        include:
-          - php: '8.2'
-            experimental: true
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
### GH Actions: add ini settings to "release" workflow

Follow-up on PR #65, which turned set `error_reporting` to `E_ALL` and turned `display_errors` on in the Test workflow.

Only just now noticed that I missed doing the same in the Release workflow.

This also changes the setting for `error_reporting` to `-1` as `E_ALL` does not contain **all** errors across PHP versions, while `-1` will show them, independently of the PHP version.

Also turning on assertions, just in case they are used under the hood in the test framework.

### GH Actions: minor simplification

No need for the `experimental` key, we can just refer directly to the `matrix.php` version in the `continue-on-error` condition.

### GH Actions: don't run the release workflow on forks

Just in case someone would push a tag up to their own fork.

### GH Actions: auto-cancel previous builds for same branch

Previously, in Travis, when the same branch was pushed again and the "Auto cancellation" option on the "Settings" page had been turned on (as it was for most repos), any still running builds for the same branch would be stopped in favour of starting the build for the newly pushed version of the branch.

To enable this behaviour in GH Actions, a `concurrency` configuration needs to be added to each workflow for which this should applied to.

More than anything, this is a way to be kind to GitHub by not wasting resources which they so kindly provide to us for free.

Refs:
* https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
* https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency