### PR TITLE
GH Actions: PHP 5.3 was missing from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - '5.3'
           - '5.4'
           - '5.5'
           - '5.6'


### PR DESCRIPTION
PR #51 restored PHP 5.3 support, but the release workflow did not test against PHP 5.3 yet.