### PR TITLE
GH Actions: version update for `ramsey/composer-install`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, zend.assertions=1
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
         with:
           composer-options: "--no-dev"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Run code sniffer
         continue-on-error: true
@@ -57,7 +57,7 @@ jobs:
           ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, zend.assertions=1
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
         with:
           composer-options: "--no-dev"
 
@@ -115,10 +115,10 @@ jobs:
       # Remove PHPCS as it has a minimum PHP requirements of PHP 5.4 and would block install on PHP 5.3.
       - name: 'Composer: remove PHPCS'
         if: ${{ matrix.php < 5.4 }}
-        run: composer remove --dev squizlabs/php_codesniffer --no-update
+        run: composer remove --dev squizlabs/php_codesniffer --no-update --no-interaction
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: 'Integration test 1 - linting own code, no colors'
         continue-on-error: true


### PR DESCRIPTION
The action used to install Composer packages and handle the caching has released a new major (and some follow-up patch releases), which means, the action reference needs to be updated to benefit from it.

Includes adding `--no-interaction` to one "plain" Composer command to potentially prevent CI hanging if, for whatever reason, interaction would be needed in the future.

Refs:
* https://github.com/ramsey/composer-install/releases/tag/2.0.0
* https://github.com/ramsey/composer-install/releases/tag/2.0.1
* https://github.com/ramsey/composer-install/releases/tag/2.0.2