### PR TITLE
Docs: show all options in help and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,25 +67,26 @@ It is strongly recommended for existing users of the (unmaintained)
 
 ## Command line options
 
-- `-p <php>`        		Specify PHP-CGI executable to run (default: 'php').
-- `-s, --short`     		Set short_open_tag to On (default: Off).
-- `-a, --asp`       		Set asp_tags to On (default: Off).
-- `-e <ext>`        		Check only files with selected extensions separated by comma. (default: php,php3,php4,php5,phtml,phpt)
-- `--exclude`       		Exclude a file or directory. If you want exclude multiple items, use multiple exclude parameters.
-- `-j <num>`        		Run <num> jobs in parallel (default: 10).
-- `--colors`        		Force enable colors in console output.
-- `--no-colors`     		Disable colors in console output.
-- `--no-progress`   		Disable progress in console output.
-- `--checkstyle`    		Output results as Checkstyle XML.
-- `--json`          		Output results as JSON string (requires PHP 5.4).
-- `--gitlab`          		Output results for the GitLab Code Quality widget (requires PHP 5.4), see more in [Code Quality](https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html) documentation.
-- `--blame`         		Try to show git blame for row with error.
-- `--git <git>`     		Path to Git executable to show blame message (default: 'git').
-- `--stdin`         		Load files and folder to test from standard input.
-- `--ignore-fails`  		Ignore failed tests.
-- `--syntax-error-callback` File with syntax error callback for ability to modify error, see more in [example](doc/syntax-error-callback.md)
-- `-h, --help`      		Print this help.
-- `-V, --version`   		Display this application version.
+- `-p <php>`                Specify PHP-CGI executable to run (default: 'php').
+- `-s`, `--short`           Set short_open_tag to On (default: Off).
+- `-a`, `--asp`             Set asp_tags to On (default: Off).
+- `-e <ext>`                Check only files with selected extensions separated by comma. (default: php,php3,php4,php5,phtml,phpt)
+- `-j <num>`                Run <num> jobs in parallel (default: 10).
+- `--exclude`               Exclude a file or directory. If you want exclude multiple items, use multiple exclude parameters.
+- `--colors`                Enable colors in console output. (disables auto detection of color support)
+- `--no-colors`             Disable colors in console output.
+- `--no-progress`           Disable progress in console output.
+- `--checkstyle`            Output results as Checkstyle XML.
+- `--json`                  Output results as JSON string (requires PHP 5.4).
+- `--gitlab`                Output results for the GitLab Code Quality Widget (requires PHP 5.4), see more in [Code Quality](https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html) documentation..
+- `--blame`                 Try to show git blame for row with error.
+- `--git <git>`             Path to Git executable to show blame message (default: 'git').
+- `--stdin`                 Load files and folder to test from standard input.
+- `--ignore-fails`          Ignore failed tests.
+- `--show-deprecated`       Show deprecations (default: Off).
+- `--syntax-error-callback` File with syntax error callback for ability to modify error, see more in [example](doc/syntax-error-callback.md).
+- `-h`, `--help`            Print this help.
+- `-V`, `--version`         Display the application version
 
 
 ## Recommended excludes for Symfony framework

--- a/src/Application.php
+++ b/src/Application.php
@@ -77,25 +77,29 @@ class Application
 Options:
     -p <php>                Specify PHP-CGI executable to run (default: 'php').
     -s, --short             Set short_open_tag to On (default: Off).
-    -a, -asp                Set asp_tags to On (default: Off).
+    -a, --asp               Set asp_tags to On (default: Off).
     -e <ext>                Check only files with selected extensions separated by comma.
                             (default: php,php3,php4,php5,phtml,phpt)
+    -j <num>                Run <num> jobs in parallel (default: 10).
     --exclude               Exclude a file or directory. If you want exclude multiple items,
                             use multiple exclude parameters.
-    -j <num>                Run <num> jobs in parallel (default: 10).
-    --colors                Enable colors in console output. (disables auto detection of color support)
+    --colors                Enable colors in console output.
+                            (disables auto detection of color support)
     --no-colors             Disable colors in console output.
     --no-progress           Disable progress in console output.
-    --json                  Output results as JSON string.
-    --gitlab                Output results for the GitLab Code Quality Widget.
     --checkstyle            Output results as Checkstyle XML.
+    --json                  Output results as JSON string
+                            (requires PHP 5.4).
+    --gitlab                Output results for the GitLab Code Quality Widget
+                            (requires PHP 5.4).
     --blame                 Try to show git blame for row with error.
     --git <git>             Path to Git executable to show blame message (default: 'git').
     --stdin                 Load files and folder to test from standard input.
     --ignore-fails          Ignore failed tests.
+    --show-deprecated       Show deprecations (default: Off).
     --syntax-error-callback File with syntax error callback for ability to modify error
     -h, --help              Print this help.
-    -V, --version           Display this application version
+    -V, --version           Display the application version
 
 HELP;
     }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -152,16 +152,16 @@ class Settings
                         $settings->aspTags = true;
                         break;
 
-                    case '--exclude':
-                        $settings->excluded[] = $arguments->getNext();
-                        break;
-
                     case '-e':
                         $settings->extensions = array_map('trim', explode(',', $arguments->getNext()));
                         break;
 
                     case '-j':
                         $settings->parallelJobs = max((int) $arguments->getNext(), 1);
+                        break;
+
+                    case '--exclude':
+                        $settings->excluded[] = $arguments->getNext();
                         break;
 
                     case '--colors':
@@ -176,16 +176,16 @@ class Settings
                         $settings->showProgress = false;
                         break;
 
+                    case '--checkstyle':
+                        $settings->format = self::FORMAT_CHECKSTYLE;
+                        break;
+
                     case '--json':
                         $settings->format = self::FORMAT_JSON;
                         break;
 
                     case '--gitlab':
                         $settings->format = self::FORMAT_GITLAB;
-                        break;
-
-                    case '--checkstyle':
-                        $settings->format = self::FORMAT_CHECKSTYLE;
                         break;
 
                     case '--git':


### PR DESCRIPTION
This commit syncs the three lists of the supported options:
* The processing of received arguments in the `Application` class.
* The CLI help in the `Settings` class.
* The options shown in the README.

I have verified that:
* The options in all three lists are now in the same order to make future maintenance more straight-forward.
    Includes having all functional short options at the top of the lists.
* All options are now shown in the help and the README.
* The descriptions in the help and in the README are complete and largely the same (minus the "further reading" links shown in the README).

Includes:
* Fixing a typo in the help `-asp` vs `--asp`.
* Line length management for the CLI help.
* Minor grammatical improvement.

Fixes #81