### PR TITLE
Composer: differentiate between dev and no-dev files for autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,12 @@
     },
     "autoload": {
         "classmap": [
-            "./"
+            "./src/"
+        ]
+    },
+    "autoload-dev": {
+        "classmap": [
+            "./tests/"
         ]
     },
     "bin": [


### PR DESCRIPTION
As suggested in JakubOnderka/PHP-Parallel-Lint#140

Props @mfn