### PR TITLE
.gitignore: remove duplicate entry

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,15 +5,14 @@
 # https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
 # https://blog.madewithlove.be/post/gitattributes/
 #
-/.gitattributes export-ignore
-/.github export-ignore
-/.gitignore export-ignore
-/.github/ export-ignore
-/appveyor.yml export-ignore
-/box.json export-ignore
-/doc export-ignore
-/phpcs.xml.dist export-ignore
-/tests export-ignore
+.gitattributes export-ignore
+.gitignore     export-ignore
+appveyor.yml   export-ignore
+box.json       export-ignore
+phpcs.xml.dist export-ignore
+/.github/      export-ignore
+/doc/          export-ignore
+/tests/        export-ignore
 
 #
 # Auto detect text files and perform LF normalization


### PR DESCRIPTION
The `.github` folder was listed twice.

Includes:
* Sorting the entries by files first, then directories.
* Improving readability of the list.