### PR TITLE
ErrorFormatter: support PHP Console Highlighter 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 [Unreleased]: https://github.com/php-parallel-lint/PHP-Parallel-Lint/compare/v1.3.2...HEAD
 
-## [1.3.2] - 2022-02-17
+## [1.3.2] - 2022-02-19
+
+### Added
+
+- Support for PHP Console Highlighter 1.0.0, which comes with PHP Console Color 1.0.1, [#92] from [@jrfnl].
 
 ### Fixed
 
@@ -56,6 +60,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#84]: https://github.com/php-parallel-lint/PHP-Parallel-Lint/pull/84
 [#88]: https://github.com/php-parallel-lint/PHP-Parallel-Lint/pull/88
 [#89]: https://github.com/php-parallel-lint/PHP-Parallel-Lint/pull/89
+[#92]: https://github.com/php-parallel-lint/PHP-Parallel-Lint/pull/92
 
 
 ## [1.3.1] - 2021-08-13

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "nette/tester": "^1.3 || ^2.0",
-        "php-parallel-lint/php-console-highlighter": "~0.3",
+        "php-parallel-lint/php-console-highlighter": "0.* || ^1.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "suggest": {

--- a/src/Output.php
+++ b/src/Output.php
@@ -456,14 +456,17 @@ class CheckstyleOutput implements Output
 
 class TextOutputColored extends TextOutput
 {
-    /** @var \JakubOnderka\PhpConsoleColor\ConsoleColor */
+    /** @var \PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor|\JakubOnderka\PhpConsoleColor\ConsoleColor */
     private $colors;
 
     public function __construct(IWriter $writer, $colors = Settings::AUTODETECT)
     {
         parent::__construct($writer);
 
-        if (class_exists('\JakubOnderka\PhpConsoleColor\ConsoleColor')) {
+        if (class_exists('\PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor')) {
+            $this->colors = new \PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor();
+            $this->colors->setForceStyle($colors === Settings::FORCED);
+        } else if (class_exists('\JakubOnderka\PhpConsoleColor\ConsoleColor')) {
             $this->colors = new \JakubOnderka\PhpConsoleColor\ConsoleColor();
             $this->colors->setForceStyle($colors === Settings::FORCED);
         }
@@ -472,11 +475,14 @@ class TextOutputColored extends TextOutput
     /**
      * @param string $string
      * @param string $type
-     * @throws \JakubOnderka\PhpConsoleColor\InvalidStyleException
+     * @throws \PHP_Parallel_Lint\PhpConsoleColor\InvalidStyleException|\JakubOnderka\PhpConsoleColor\InvalidStyleException
      */
     public function write($string, $type = self::TYPE_DEFAULT)
     {
-        if (!$this->colors instanceof \JakubOnderka\PhpConsoleColor\ConsoleColor) {
+        if (
+            !$this->colors instanceof \PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor
+            && !$this->colors instanceof \JakubOnderka\PhpConsoleColor\ConsoleColor
+        ) {
             parent::write($string, $type);
         } else {
             switch ($type) {


### PR DESCRIPTION
PHP Console Highlighter 1.0.0 has just been released.

This PR adds cross-version support for both PHP Console Highlighter < 1.0.0 and 1.0.0+ to PHP Parallel Lint, which allows people to update the Highlighter dependency to the latest version.

Includes changelog entry to allow this PR to still be included in the 1.3.2 release.

Ref: https://github.com/php-parallel-lint/PHP-Console-Highlighter/releases/tag/v1.0.0