### PR TITLE
ErrorFormatter: fix error msg on last line of code snippet

### DIFF
--- a/src/ErrorFormatter.php
+++ b/src/ErrorFormatter.php
@@ -60,6 +60,7 @@ class ErrorFormatter
                 } else {
                     $string .= $this->getCodeSnippet($error->getFilePath(), $onLine);
                 }
+                $string = rtrim($string) . PHP_EOL;
             }
         }
 


### PR DESCRIPTION
This small tweak makes the display of the error message independent of the code snippet implementation and will ensure that the actual error message is always displayed on the next line after the code snippet.

Fixes #93