### PR TITLE
Application bootstrap: fix version check

### DIFF
--- a/parallel-lint
+++ b/parallel-lint
@@ -31,7 +31,15 @@ either expressed or implied, of the FreeBSD Project.
  */
 
 if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50300) {
-    fwrite(STDERR, "PHP Parallel Lint requires PHP 5.3.0 or newer." . PHP_EOL);
+    fwrite(
+        STDERR,
+        sprintf(
+            'PHP Parallel Lint requires PHP 5.3.0 or newer.' . PHP_EOL
+            . 'You are using PHP %s (%s).' . PHP_EOL,
+            PHP_VERSION,
+            PHP_BINDIR
+        )
+    );
     exit(254);
 }
 

--- a/parallel-lint
+++ b/parallel-lint
@@ -70,5 +70,7 @@ if (!$loaded) {
 
 require_once __DIR__ . '/src/polyfill.php';
 
-$app = new PHP_Parallel_Lint\PhpParallelLint\Application();
+// Prevent parse error on PHP < 5.3 so the version check above can work.
+$className = 'PHP_Parallel_Lint\PhpParallelLint\Application';
+$app = new $className();
 exit($app->run());


### PR DESCRIPTION
### Allow version check in application entry file to work

As reported in #62, the "version check" for PHP < 5.3 in the application bootstrap did not work as the code in file would cause a parse error when run on PHP < 5.3.

By putting the class name, which contains PHP 5.3 namespace separator tokens, as a variable and then dynamically calling the class, the parse error on PHP < 5.3 is prevented and the version check at the top of the file can work as expected.

Fixes #62

**_Note_**: this is not something which can really be unit tested as this concerns the application bootstrap file. An integration test would be an option, but then, this integration test would need to be run against PHP 5.2 (or lower) in a workflow.
Adding a setup for this is outside the scope of this PR.

### Make the version check more informative

Previously, the PHP version check run at the start of the script would display `PHP Parallel Lint requires PHP 5.3.0 or newer.` if the PHP version was too low.

The message has been updated to include the currently detected PHP version and the path to the PHP binary.

Note: both constants used are available in PHP cross-version

### Testing the PR

* On PHP 5.2, with `develop` or `master`: try to run the `parallel-lint` command and see it fail with a parse error.
* Switch to this branch.
* Try running the `parallel-lint` command again and see it fail with an informative error message saying that "PHP Parallel Lint requires PHP 5.3.o or newer"