### PR TITLE
Use PHP-Code-Style 2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,10 +112,10 @@ jobs:
           ini-values: error_reporting=-1, display_errors=On, zend.assertions=1
           coverage: none
 
-      # Remove PHPCS as it has a minimum PHP requirements of PHP 5.4 and would block install on PHP 5.3.
+      # Remove the PHPCS standard as it has a minimum PHP requirements of PHP 5.4 and would block install on PHP 5.3.
       - name: 'Composer: remove PHPCS'
         if: ${{ matrix.php < 5.4 }}
-        run: composer remove --dev squizlabs/php_codesniffer --no-update --no-interaction
+        run: composer remove --dev php-parallel-lint/php-code-style --no-update --no-interaction
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2

--- a/bin/skip-linting.php
+++ b/bin/skip-linting.php
@@ -1,4 +1,5 @@
 <?php
+
 $stdin = fopen('php://stdin', 'r');
 $input = stream_get_contents($stdin);
 fclose($stdin);

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,16 @@
     "require-dev": {
         "nette/tester": "^1.3 || ^2.0",
         "php-parallel-lint/php-console-highlighter": "0.* || ^1.0",
-        "squizlabs/php_codesniffer": "^3.6"
+        "php-parallel-lint/php-code-style": "^2.0"
     },
     "suggest": {
         "php-parallel-lint/php-console-highlighter": "Highlight syntax in code snippet"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -41,6 +41,9 @@
     <rule ref="PHPParallelLint">
         <!-- For improved readability, a blank line should be allowed before the next leaf in a if/else control structure. -->
         <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
+
+        <!-- This package includes a polyfill for the JsonSerializable interface. -->
+        <exclude name="PHPCompatibility.Interfaces.NewInterfaces.jsonserializableFound"/>
     </rule>
 
     <rule ref="Generic.PHP.NoSilencedErrors">
@@ -52,6 +55,52 @@
             <property name="lineLimit" value="135"/>
             <property name="absoluteLineLimit" value="200"/>
         </properties>
+    </rule>
+
+
+    <!--
+    #############################################################################
+    SELECTIVE EXCLUSIONS
+    Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
+    #############################################################################
+    -->
+
+    <!-- Polyfill for PHP native interface, can't be in a namespace. -->
+    <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+        <exclude-pattern>src/polyfill\.php$</exclude-pattern>
+    </rule>
+
+
+    <!--
+    #############################################################################
+    TEMPORARY EXCLUSIONS
+    These adjustments should be removed once the codebase has been fixed up.
+    #############################################################################
+    -->
+
+    <!-- To be addressed at a later point in time. -->
+    <rule ref="Generic.Metrics.CyclomaticComplexity">
+        <exclude-pattern>/src/(Application|ParallelLint|Settings|Outputs/TextOutput)\.php$</exclude-pattern>
+    </rule>
+
+    <!-- To be addressed in test refactor. -->
+    <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+        <exclude-pattern>/tests/Output\.phpt$</exclude-pattern>
+    </rule>
+    <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+        <exclude-pattern>/tests/*\.php[t]?$</exclude-pattern>
+    </rule>
+    <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+        <exclude-pattern>/tests/*\.phpt$</exclude-pattern>
+    </rule>
+    <rule ref="PSR12.Files.FileHeader.SpacingAfterBlock">
+        <exclude-pattern>/tests/skip-on-5.3/trait\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PSR12.Files.OpenTag.NotAlone">
+        <exclude-pattern>/tests/skip-on-5.3/trait\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Keywords.NewKeywords.t_traitFound">
+        <exclude-pattern>/tests/skip-on-5.3/trait\.php$</exclude-pattern>
     </rule>
 
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP-Parallel-Lint" xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+<ruleset name="PHP-Parallel-Lint">
     <description>PHP Parallel Lint coding standard.</description>
 
     <!--
@@ -9,9 +9,10 @@
     #############################################################################
     -->
 
+    <!-- Scan all files. -->
     <file>.</file>
 
-    <!-- Exclude the Examples directory and the Composer vendor directory. -->
+    <!-- Exclude dependencies, test fixtures. -->
     <exclude-pattern>*/tests/examples/*</exclude-pattern>
     <exclude-pattern>*/vendor/*</exclude-pattern>
 
@@ -27,48 +28,24 @@
     <!-- Check up to 8 files simultaneously. -->
     <arg name="parallel" value="8"/>
 
+
     <!--
     #############################################################################
-    RULES
+    USE THE PHPParallelLint RULESET
     #############################################################################
     -->
 
-    <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
-    <rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman"/>
-    <rule ref="PEAR.Functions.FunctionDeclaration"/>
-    <rule ref="PEAR.Functions.FunctionCallSignature"/>
-    <rule ref="PEAR.Functions.FunctionCallSignature.Indent">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Functions.ValidDefaultValue"/>
-    <rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman"/>
+    <!-- Set the supported PHP versions for PHPCompatibility (included in PHPParallelLint). -->
+    <config name="testVersion" value="5.3-"/>
 
-    <rule ref="Generic.PHP.DisallowShortOpenTag"/>
-    <rule ref="Generic.PHP.LowerCaseConstant"/>
+    <rule ref="PHPParallelLint">
+        <!-- For improved readability, a blank line should be allowed before the next leaf in a if/else control structure. -->
+        <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
+    </rule>
+
     <rule ref="Generic.PHP.NoSilencedErrors">
         <exclude-pattern>/bin/skip-linting\.php$</exclude-pattern>
     </rule>
-    <rule ref="Squiz.PHP.GlobalKeyword"/>
-    <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
-    <rule ref="Squiz.PHP.NonExecutableCode"/>
-    <rule ref="Generic.PHP.ForbiddenFunctions"/>
-    <rule ref="Generic.PHP.DeprecatedFunctions"/>
-
-    <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
-
-    <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
-    <rule ref="PEAR.WhiteSpace.ScopeClosingBrace"/>
-
-    <rule ref="PEAR.Classes.ClassDeclaration"/>
-
-    <rule ref="Generic.ControlStructures.InlineControlStructure"/>
-    <rule ref="PEAR.ControlStructures.ControlSignature"/>
 
     <rule ref="Generic.Files.LineLength">
         <properties>
@@ -76,28 +53,5 @@
             <property name="absoluteLineLimit" value="200"/>
         </properties>
     </rule>
-    <rule ref="Zend.Files.ClosingTag"/>
-    <rule ref="Generic.Files.LineEndings"/>
-
-    <rule ref="Generic.NamingConventions.ConstructorName"/>
-    <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
-
-    <rule ref="Generic.Metrics.NestingLevel"/>
-
-    <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
-    <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
-    <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
-    <rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
-    <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
-    <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
-
-    <rule ref="PEAR.Commenting.InlineComment"/>
-
-    <rule ref="Generic.Formatting.SpaceAfterCast"/>
-    <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
-
-    <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
-    <rule ref="Squiz.ControlStructures.ElseIfDeclaration"/>
-    <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
 
 </ruleset>

--- a/src/Application.php
+++ b/src/Application.php
@@ -44,7 +44,7 @@ class Application
                 $this->showUsage();
                 return self::FAILED;
             }
-            $manager = new Manager;
+            $manager = new Manager();
             $result = $manager->run($settings);
             if ($settings->ignoreFails) {
                 return $result->hasSyntaxError() ? self::WITH_ERRORS : self::SUCCESS;
@@ -112,7 +112,7 @@ HELP;
      */
     private function showVersion()
     {
-        echo 'PHP Parallel Lint version ' . self::VERSION.PHP_EOL;
+        echo 'PHP Parallel Lint version ', self::VERSION, PHP_EOL;
     }
 
     /**

--- a/src/Blame.php
+++ b/src/Blame.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint;
 
 use ReturnTypeWillChange;
@@ -24,7 +25,7 @@ class Blame implements \JsonSerializable
      * which is a value of any type other than a resource.
      */
     #[ReturnTypeWillChange]
-    function jsonSerialize()
+    public function jsonSerialize()
     {
         return array(
             'name' => $this->name,

--- a/src/Contracts/SyntaxErrorCallback.php
+++ b/src/Contracts/SyntaxErrorCallback.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Contracts;
 
 use PHP_Parallel_Lint\PhpParallelLint\Errors\SyntaxError;

--- a/src/ErrorFormatter.php
+++ b/src/ErrorFormatter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint;
 
 use JakubOnderka\PhpConsoleColor\ConsoleColor as OldConsoleColor;
@@ -123,7 +124,7 @@ class ErrorFormatter
             $colors = new ConsoleColor();
             $colors->setForceStyle($this->forceColors);
             $highlighter = new Highlighter($colors);
-        } else if (
+        } elseif (
             class_exists('\JakubOnderka\PhpConsoleHighlighter\Highlighter')
             && class_exists('\JakubOnderka\PhpConsoleColor\ConsoleColor')
         ) {

--- a/src/Errors/ParallelLintError.php
+++ b/src/Errors/ParallelLintError.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Errors;
 
 use ReturnTypeWillChange;

--- a/src/Errors/SyntaxError.php
+++ b/src/Errors/SyntaxError.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Errors;
 
 use PHP_Parallel_Lint\PhpParallelLint\Blame;

--- a/src/Exceptions/CallbackNotImplementedException.php
+++ b/src/Exceptions/CallbackNotImplementedException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Exceptions;
 
 class CallbackNotImplementedException extends ParallelLintException

--- a/src/Exceptions/ClassNotFoundException.php
+++ b/src/Exceptions/ClassNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Exceptions;
 
 class ClassNotFoundException extends ParallelLintException

--- a/src/Exceptions/InvalidArgumentException.php
+++ b/src/Exceptions/InvalidArgumentException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Exceptions;
 
 class InvalidArgumentException extends ParallelLintException

--- a/src/Exceptions/ParallelLintException.php
+++ b/src/Exceptions/ParallelLintException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Exceptions;
 
 use ReturnTypeWillChange;

--- a/src/Exceptions/PathNotFoundException.php
+++ b/src/Exceptions/PathNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Exceptions;
 
 class PathNotFoundException extends ParallelLintException

--- a/src/Exceptions/RuntimeException.php
+++ b/src/Exceptions/RuntimeException.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Exceptions;
 
 class RuntimeException extends ParallelLintException
 {
-
 }

--- a/src/Iterators/ArrayIterator.php
+++ b/src/Iterators/ArrayIterator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Iterators;
 
 class ArrayIterator extends \ArrayIterator

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint;
 
 use PHP_Parallel_Lint\PhpParallelLint\Contracts\SyntaxErrorCallback;
@@ -30,7 +31,7 @@ class Manager
      */
     public function run(Settings $settings = null)
     {
-        $settings = $settings ?: new Settings;
+        $settings = $settings ?: new Settings();
         $output = $this->output ?: $this->getDefaultOutput($settings);
 
         $phpExecutable = PhpExecutable::getPhpExecutable($settings->phpExecutable);
@@ -56,9 +57,9 @@ class Manager
         $parallelLint->setProcessCallback(function ($status, $file) use ($output) {
             if ($status === ParallelLint::STATUS_OK) {
                 $output->ok();
-            } else if ($status === ParallelLint::STATUS_SKIP) {
+            } elseif ($status === ParallelLint::STATUS_SKIP) {
                 $output->skip();
-            } else if ($status === ParallelLint::STATUS_ERROR) {
+            } elseif ($status === ParallelLint::STATUS_ERROR) {
                 $output->error();
             } else {
                 $output->fail();
@@ -90,7 +91,7 @@ class Manager
      */
     protected function getDefaultOutput(Settings $settings)
     {
-        $writer = new ConsoleWriter;
+        $writer = new ConsoleWriter();
         switch ($settings->format) {
             case Settings::FORMAT_JSON:
                 return new JsonOutput($writer);
@@ -128,7 +129,7 @@ class Manager
                 $process->waitForFinish();
 
                 if ($process->isSuccess()) {
-                    $blame = new Blame;
+                    $blame = new Blame();
                     $blame->name = $process->getAuthor();
                     $blame->email = $process->getAuthorEmail();
                     $blame->datetime = $process->getAuthorTime();
@@ -157,7 +158,7 @@ class Manager
         foreach ($paths as $path) {
             if (is_file($path)) {
                 $files[] = $path;
-            } else if (is_dir($path)) {
+            } elseif (is_dir($path)) {
                 $iterator = new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS);
                 if (!empty($excluded)) {
                     $iterator = new RecursiveDirectoryFilterIterator($iterator, $excluded);
@@ -202,7 +203,7 @@ class Manager
             throw new ClassNotFoundException($expectedClassName, $settings->syntaxErrorCallbackFile);
         }
 
-        $callbackInstance = new $expectedClassName;
+        $callbackInstance = new $expectedClassName();
 
         if (!($callbackInstance instanceof SyntaxErrorCallback)) {
             throw new CallbackNotImplementedException($expectedClassName);

--- a/src/Outputs/CheckstyleOutput.php
+++ b/src/Outputs/CheckstyleOutput.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Outputs;
 
 use PHP_Parallel_Lint\PhpParallelLint\ErrorFormatter;

--- a/src/Outputs/GitLabOutput.php
+++ b/src/Outputs/GitLabOutput.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Outputs;
 
 use PHP_Parallel_Lint\PhpParallelLint\Outputs\OutputInterface;

--- a/src/Outputs/JsonOutput.php
+++ b/src/Outputs/JsonOutput.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Outputs;
 
 use PHP_Parallel_Lint\PhpParallelLint\ErrorFormatter;
@@ -29,27 +30,22 @@ class JsonOutput implements OutputInterface
 
     public function ok()
     {
-
     }
 
     public function skip()
     {
-
     }
 
     public function error()
     {
-
     }
 
     public function fail()
     {
-
     }
 
     public function setTotalFileCount($count)
     {
-
     }
 
     public function writeHeader($phpVersion, $parallelJobs, $hhvmVersion = null)

--- a/src/Outputs/OutputInterface.php
+++ b/src/Outputs/OutputInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Outputs;
 
 use PHP_Parallel_Lint\PhpParallelLint\ErrorFormatter;

--- a/src/Outputs/TextOutput.php
+++ b/src/Outputs/TextOutput.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Outputs;
 
 use PHP_Parallel_Lint\PhpParallelLint\ErrorFormatter;
@@ -175,13 +176,13 @@ class TextOutput implements OutputInterface
             if ($type === self::TYPE_OK) {
                 $this->writer->write('.');
 
-            } else if ($type === self::TYPE_SKIP) {
+            } elseif ($type === self::TYPE_SKIP) {
                 $this->write('S', self::TYPE_SKIP);
 
-            } else if ($type === self::TYPE_ERROR) {
+            } elseif ($type === self::TYPE_ERROR) {
                 $this->write('X', self::TYPE_ERROR);
 
-            } else if ($type === self::TYPE_FAIL) {
+            } elseif ($type === self::TYPE_FAIL) {
                 $this->writer->write('-');
             }
 

--- a/src/Outputs/TextOutputColored.php
+++ b/src/Outputs/TextOutputColored.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Outputs;
 
 use PHP_Parallel_Lint\PhpParallelLint\Settings;
@@ -16,7 +17,7 @@ class TextOutputColored extends TextOutput
         if (class_exists('\PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor')) {
             $this->colors = new \PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor();
             $this->colors->setForceStyle($colors === Settings::FORCED);
-        } else if (class_exists('\JakubOnderka\PhpConsoleColor\ConsoleColor')) {
+        } elseif (class_exists('\JakubOnderka\PhpConsoleColor\ConsoleColor')) {
             $this->colors = new \JakubOnderka\PhpConsoleColor\ConsoleColor();
             $this->colors->setForceStyle($colors === Settings::FORCED);
         }

--- a/src/ParallelLint.php
+++ b/src/ParallelLint.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint;
 
 use PHP_Parallel_Lint\PhpParallelLint\Contracts\SyntaxErrorCallback;
@@ -93,19 +94,18 @@ class ParallelLint
                     if ($skipStatus === null) {
                         $waiting[$file] = $process;
 
-                    } else if ($skipStatus === true) {
+                    } elseif ($skipStatus === true) {
                         $skippedFiles[] = $file;
                         $processCallback(self::STATUS_SKIP, $file);
 
-                    } else if ($process->containsError()) {
+                    } elseif ($process->containsError()) {
                         $checkedFiles[] = $file;
                         $errors[] = $this->triggerSyntaxErrorCallback(new SyntaxError($file, $process->getSyntaxError()));
                         $processCallback(self::STATUS_ERROR, $file);
 
-                    } else if ($process->isSuccess()) {
+                    } elseif ($process->isSuccess()) {
                         $checkedFiles[] = $file;
                         $processCallback(self::STATUS_OK, $file);
-
 
                     } else {
                         $errors[] = new ParallelLintError($file, $process->getOutput());
@@ -128,15 +128,15 @@ class ParallelLint
                 if ($skipStatus === null) {
                     throw new \Exception("File $file has empty skip status. Please contact the author of PHP Parallel Lint.");
 
-                } else if ($skipStatus === true) {
+                } elseif ($skipStatus === true) {
                     $skippedFiles[] = $file;
                     $processCallback(self::STATUS_SKIP, $file);
 
-                } else if ($process->isSuccess()) {
+                } elseif ($process->isSuccess()) {
                     $checkedFiles[] = $file;
                     $processCallback(self::STATUS_OK, $file);
 
-                } else if ($process->containsError()) {
+                } elseif ($process->containsError()) {
                     $checkedFiles[] = $file;
                     $errors[] = $this->triggerSyntaxErrorCallback(new SyntaxError($file, $process->getSyntaxError()));
                     $processCallback(self::STATUS_ERROR, $file);

--- a/src/Process/GitBlameProcess.php
+++ b/src/Process/GitBlameProcess.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Process;
 
 use PHP_Parallel_Lint\PhpParallelLint\Exceptions\RuntimeException;

--- a/src/Process/LintProcess.php
+++ b/src/Process/LintProcess.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Process;
 
 use PHP_Parallel_Lint\PhpParallelLint\Exceptions\ParallelLintException;

--- a/src/Process/Process.php
+++ b/src/Process/Process.php
@@ -74,7 +74,7 @@ class Process
 
         if ($status['running']) {
             return false;
-        } else if ($this->statusCode === null) {
+        } elseif ($this->statusCode === null) {
             $this->statusCode = (int) $status['exitcode'];
         }
 

--- a/src/Process/SkipLintProcess.php
+++ b/src/Process/SkipLintProcess.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Process;
 
 use PHP_Parallel_Lint\PhpParallelLint\Exceptions\RuntimeException;

--- a/src/Result.php
+++ b/src/Result.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint;
 
 use PHP_Parallel_Lint\PhpParallelLint\Errors\ParallelLintError;
@@ -159,7 +160,7 @@ class Result implements \JsonSerializable
      * which is a value of any type other than a resource.
      */
     #[ReturnTypeWillChange]
-    function jsonSerialize()
+    public function jsonSerialize()
     {
         return array(
             'checkedFiles' => $this->getCheckedFiles(),
@@ -168,6 +169,4 @@ class Result implements \JsonSerializable
             'errors' => $this->getErrors(),
         );
     }
-
-
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint;
 
 use PHP_Parallel_Lint\PhpParallelLint\Exceptions\InvalidArgumentException;
@@ -6,7 +7,6 @@ use PHP_Parallel_Lint\PhpParallelLint\Iterators\ArrayIterator;
 
 class Settings
 {
-
     /**
      * constants for enum settings
      */
@@ -129,10 +129,11 @@ class Settings
     public static function parseArguments(array $arguments)
     {
         $arguments = new ArrayIterator(array_slice($arguments, 1));
-        $settings = new self;
+        $settings = new self();
 
         // Use the currently invoked php as the default if possible
         if (defined('PHP_BINARY')) {
+            // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_binaryFound
             $settings->phpExecutable = PHP_BINARY;
         }
 

--- a/src/Writers/ConsoleWriter.php
+++ b/src/Writers/ConsoleWriter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Writers;
 
 class ConsoleWriter implements WriterInterface

--- a/src/Writers/FileWriter.php
+++ b/src/Writers/FileWriter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Writers;
 
 class FileWriter implements WriterInterface

--- a/src/Writers/MultipleWriter.php
+++ b/src/Writers/MultipleWriter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Writers;
 
 class MultipleWriter implements WriterInterface

--- a/src/Writers/NullWriter.php
+++ b/src/Writers/NullWriter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Writers;
 
 class NullWriter implements WriterInterface

--- a/src/Writers/WriterInterface.php
+++ b/src/Writers/WriterInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpParallelLint\Writers;
 
 interface WriterInterface

--- a/src/polyfill.php
+++ b/src/polyfill.php
@@ -3,6 +3,7 @@
 /**
  * Polyfill for PHP < 5.4
  */
+
 if (!interface_exists('JsonSerializable', false)) {
     interface JsonSerializable
     {
@@ -10,6 +11,6 @@ if (!interface_exists('JsonSerializable', false)) {
          * @param void
          * @return mixed
          */
-        function jsonSerialize();
+        public function jsonSerialize();
     }
 }

--- a/tests/Manager.run.phpt
+++ b/tests/Manager.run.phpt
@@ -136,5 +136,5 @@ class ManagerRunTest extends Tester\TestCase
     }
 }
 
-$testCase = new ManagerRunTest;
+$testCase = new ManagerRunTest();
 $testCase->run();

--- a/tests/Output.phpt
+++ b/tests/Output.phpt
@@ -116,5 +116,5 @@ class TestWriter implements WriterInterface
     }
 }
 
-$testCase = new OutputTest;
+$testCase = new OutputTest();
 $testCase->run();

--- a/tests/ParallelLint.lint.phpt
+++ b/tests/ParallelLint.lint.phpt
@@ -102,7 +102,7 @@ class ParallelLintLintTest extends Tester\TestCase
         Assert::false($result->hasSyntaxError());
         Assert::equal(0, count($result->getErrors()));
 
-        if (PHP_VERSION_ID < 70000 || PHP_VERSION_ID >= 80000 ) {
+        if (PHP_VERSION_ID < 70000 || PHP_VERSION_ID >= 80000) {
             Tester\Environment::skip('test for php version 7.0-7.4');
         }
 
@@ -135,5 +135,5 @@ class ParallelLintLintTest extends Tester\TestCase
     }
 }
 
-$testCase = new ParallelLintLintTest;
+$testCase = new ParallelLintLintTest();
 $testCase->run();

--- a/tests/Settings.parseArguments.phpt
+++ b/tests/Settings.parseArguments.phpt
@@ -145,5 +145,5 @@ class SettingsParseArgumentsTest extends Tester\TestCase
     }
 }
 
-$testCase = new SettingsParseArgumentsTest;
+$testCase = new SettingsParseArgumentsTest();
 $testCase->run();

--- a/tests/SkipLintProcess.phpt
+++ b/tests/SkipLintProcess.phpt
@@ -37,5 +37,5 @@ class SkipLintProcessTest extends Tester\TestCase
     }
 }
 
-$skipLintProcessTest = new SkipLintProcessTest;
+$skipLintProcessTest = new SkipLintProcessTest();
 $skipLintProcessTest->run();

--- a/tests/SyntaxError.normalizeMessage.phpt
+++ b/tests/SyntaxError.normalizeMessage.phpt
@@ -27,5 +27,5 @@ class SyntaxErrorNormalizeMessageTest extends Tester\TestCase
     }
 }
 
-$testCase = new SyntaxErrorNormalizeMessageTest;
+$testCase = new SyntaxErrorNormalizeMessageTest();
 $testCase->run();

--- a/tests/skip-on-5.3/class.php
+++ b/tests/skip-on-5.3/class.php
@@ -2,5 +2,4 @@
 
 class ExampleClass
 {
-
 }

--- a/tests/skip-on-5.3/trait.php
+++ b/tests/skip-on-5.3/trait.php
@@ -2,5 +2,4 @@
 
 trait ExampleTrait
 {
-
 }


### PR DESCRIPTION
### PHPCS: use PHP-Code-Style 2.0

* Composer: require `php-parallel-lint/php-code-style` at 2.0 or higher.
* Composer: remove the requirement for PHPCS. This will now be inherited from the code style repo.
* Composer: allow execution of the PHPCS Composer plugin, which is a dependency of the PHP Code Style repo.
* GH Actions, test workflow: adjust the removal of the PHPCS dependency to match.

### Ruleset: update for PHP-Code-Style 2.0

* Use the ruleset from PHP-Code-Style, but keep the custom property settings.
* Set the `testVersion` for use with PHPCompatibility.
* Improve the documentation in the ruleset.

### Ruleset: add a few selective exclusions

... for things to be addressed at a later point in time and a few which don't need addressing at all.

### CS: various minor fixes

Fix up the issues which will be flagged by PHP-Code-Style 2.0 and explicitly ignore a couple of (non-)issues.