### PR TITLE
SettingsParseArgumentsTest: fix bug in test

### DIFF
--- a/tests/Settings.parseArguments.phpt
+++ b/tests/Settings.parseArguments.phpt
@@ -58,7 +58,7 @@ class SettingsParseArgumentsTest extends Tester\TestCase
         $expectedSettings->colors = Settings::DISABLED;
         $expectedSettings->showProgress = true;
         $expectedSettings->format = Settings::FORMAT_TEXT;
-        $expectedSettings->deprecated = false;
+        $expectedSettings->showDeprecated = false;
 
         Assert::equal($expectedSettings->shortTag, $settings->shortTag);
         Assert::equal($expectedSettings->aspTags, $settings->aspTags);


### PR DESCRIPTION
The `SettingsParseArgumentsTest::testMoreArguments()` method was assigning to a non-existent property in the `Settings` class.
The actual property is called `$showDeprecated` and the assertion was referring to the property correctly.