### PR TITLE
CS/QA: Tests: add PSR-4 compliant namespace declarations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,9 +37,9 @@
         }
     },
     "autoload-dev": {
-        "classmap": [
-            "./tests/"
-        ]
+        "psr-4": {
+            "PHP_Parallel_Lint\\PhpParallelLint\\Tests\\": "tests/"
+        }
     },
     "bin": [
         "parallel-lint"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -85,13 +85,13 @@
 
     <!-- To be addressed in test refactor. -->
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
-        <exclude-pattern>/tests/Output\.phpt$</exclude-pattern>
-    </rule>
-    <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
-        <exclude-pattern>/tests/*\.php[t]?$</exclude-pattern>
+        <exclude-pattern>/tests/OutputTest\.php$</exclude-pattern>
     </rule>
     <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
-        <exclude-pattern>/tests/*\.phpt$</exclude-pattern>
+        <exclude-pattern>/tests/*\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+        <exclude-pattern>/tests/skip-on-5\.3/*\.php$</exclude-pattern>
     </rule>
     <rule ref="PSR12.Files.FileHeader.SpacingAfterBlock">
         <exclude-pattern>/tests/skip-on-5.3/trait\.php$</exclude-pattern>

--- a/tests/ManagerRunTest.php
+++ b/tests/ManagerRunTest.php
@@ -4,6 +4,8 @@
  * @testCase
  */
 
+namespace PHP_Parallel_Lint\PhpParallelLint\Tests;
+
 require_once __DIR__ . '/../src/polyfill.php';
 require __DIR__ . '/../vendor/autoload.php';
 

--- a/tests/OutputTest.php
+++ b/tests/OutputTest.php
@@ -4,6 +4,8 @@
  * @testCase
  */
 
+namespace PHP_Parallel_Lint\PhpParallelLint\Tests;
+
 require_once __DIR__ . '/../src/polyfill.php';
 require __DIR__ . '/../vendor/autoload.php';
 

--- a/tests/ParallelLintLintTest.php
+++ b/tests/ParallelLintLintTest.php
@@ -4,6 +4,8 @@
  * @testCase
  */
 
+namespace PHP_Parallel_Lint\PhpParallelLint\Tests;
+
 require_once __DIR__ . '/../src/polyfill.php';
 require __DIR__ . '/../vendor/autoload.php';
 

--- a/tests/SettingsParseArgumentsTest.php
+++ b/tests/SettingsParseArgumentsTest.php
@@ -4,6 +4,8 @@
  * @testCase
  */
 
+namespace PHP_Parallel_Lint\PhpParallelLint\Tests;
+
 require_once __DIR__ . '/../src/polyfill.php';
 require __DIR__ . '/../vendor/autoload.php';
 

--- a/tests/SkipLintProcessTest.php
+++ b/tests/SkipLintProcessTest.php
@@ -4,6 +4,8 @@
  * @testCase
  */
 
+namespace PHP_Parallel_Lint\PhpParallelLint\Tests;
+
 require_once __DIR__ . '/../src/polyfill.php';
 require __DIR__ . '/../vendor/autoload.php';
 

--- a/tests/SyntaxErrorNormalizeMessageTest.php
+++ b/tests/SyntaxErrorNormalizeMessageTest.php
@@ -4,6 +4,8 @@
  * @testCase
  */
 
+namespace PHP_Parallel_Lint\PhpParallelLint\Tests;
+
 require_once __DIR__ . '/../src/polyfill.php';
 require __DIR__ . '/../vendor/autoload.php';
 


### PR DESCRIPTION
Includes:
* Renaming the files to reflect the name of the class therein and to use the `php` instead of `phpt` file extension.
* Updating the `autoload-dev` directive in the `composer.json` file.
* Updating the exclusions in the PHPCS config.

Note: using PSR-4 compliant `*Test,php` filenames will (temporarily) silently break the running of the tests for PHP 5.3-5.5 as Nette Tester 1.x can't find the tests anymore.
We can ignore this for now as this will be fixed in one of the next PRs where the tests will switch over to the PHPUnit testing framework.