### PR TITLE
SettingsParseArgumentsTest: improve the tests

### DIFF
--- a/tests/Unit/SettingsParseArgumentsTest.php
+++ b/tests/Unit/SettingsParseArgumentsTest.php
@@ -8,6 +8,48 @@ use PHP_Parallel_Lint\PhpParallelLint\Tests\UnitTestCase;
 class SettingsParseArgumentsTest extends UnitTestCase
 {
     /**
+     * Test that an exception is thrown when an unsupported argument is passed.
+     *
+     * @dataProvider dataParseArgumentsInvalidArgument
+     *
+     * @param string $command     The command as received from the command line.
+     * @param string $unsupported The unsupported argument which should trigger the exception.
+     *
+     * @return void
+     */
+    public function testParseArgumentsInvalidArgument($command, $unsupported)
+    {
+        $this->expectExceptionPolyfill('PHP_Parallel_Lint\PhpParallelLint\Exceptions\InvalidArgumentException');
+        $this->expectExceptionMessagePolyfill('Invalid argument ' . $unsupported);
+
+        $argv = explode(' ', $command);
+        Settings::parseArguments($argv);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataParseArgumentsInvalidArgument()
+    {
+        return array(
+            'Unsupported short argument' => array(
+                'command'     => './parallel-lint --colors -u . --exclude vendor',
+                'unsupported' => '-u',
+            ),
+            'Unsupported long argument' => array(
+                'command'     => './parallel-lint . --no-progress --unsupported-arg',
+                'unsupported' => '--unsupported-arg',
+            ),
+            'Unsupported argument split by = sign' => array(
+                'command'     => './parallel-lint --exclude=vendor',
+                'unsupported' => '--exclude=vendor',
+            ),
+        );
+    }
+
+    /**
      * Test parsing the arguments received from the command line.
      *
      * @dataProvider dataParseArguments

--- a/tests/Unit/SettingsParseArgumentsTest.php
+++ b/tests/Unit/SettingsParseArgumentsTest.php
@@ -5,6 +5,10 @@ namespace PHP_Parallel_Lint\PhpParallelLint\Tests\Unit;
 use PHP_Parallel_Lint\PhpParallelLint\Settings;
 use PHP_Parallel_Lint\PhpParallelLint\Tests\UnitTestCase;
 
+/**
+ * @covers \PHP_Parallel_Lint\PhpParallelLint\Settings::parseArguments
+ * @covers \PHP_Parallel_Lint\PhpParallelLint\Iterators\ArrayIterator
+ */
 class SettingsParseArgumentsTest extends UnitTestCase
 {
     /**

--- a/tests/Unit/SettingsParseArgumentsTest.php
+++ b/tests/Unit/SettingsParseArgumentsTest.php
@@ -36,10 +36,41 @@ class SettingsParseArgumentsTest extends UnitTestCase
     public function dataParseArguments()
     {
         return array(
+            'No arguments at all' => array(
+                'command'         => './parallel-lint',
+                'expectedChanged' => array(),
+            ),
             'No arguments other than the path' => array(
                 'command'         => './parallel-lint .',
                 'expectedChanged' => array(
                     'paths' => array('.'),
+                ),
+            ),
+            'No arguments other than multiple paths in varying formats' => array(
+                'command'         => './parallel-lint ./src /tests bin ' . __DIR__ . '/../absolute/',
+                'expectedChanged' => array(
+                    'paths' => array(
+                        './src',
+                        '/tests',
+                        'bin',
+                        __DIR__ . '/../absolute/',
+                    ),
+                ),
+            ),
+            'Custom path to PHP' => array(
+                'command'         => 'parallel-lint -p path/to/php.exe .',
+                'expectedChanged' => array(
+                    'phpExecutable' => 'path/to/php.exe',
+                    'paths'         => array('.'),
+                ),
+            ),
+            'Multiple short arguments: -s -a -j 20' => array(
+                'command'         => 'parallel-lint -s -a -j 20 .',
+                'expectedChanged' => array(
+                    'shortTag'     => true,
+                    'aspTags'      => true,
+                    'parallelJobs' => 20,
+                    'paths'        => array('.'),
                 ),
             ),
             'Multiple extensions, comma separated' => array(
@@ -49,12 +80,24 @@ class SettingsParseArgumentsTest extends UnitTestCase
                     'paths'      => array('.'),
                 ),
             ),
-            'Multiple arguments' => array(
-                'command'         => './parallel-lint --exclude vendor --no-colors .',
+            'Multiple long arguments' => array(
+                'command'         => './parallel-lint --exclude vendor --short --asp .',
                 'expectedChanged' => array(
                     'excluded' => array('vendor'),
-                    'colors'   => Settings::DISABLED,
+                    'shortTag' => true,
+                    'aspTags'  => true,
                     'paths'    => array('.'),
+                ),
+            ),
+            'Multiple excludes, including subdir' => array(
+                'command'         => './parallel-lint . --exclude .git --exclude node_modules --exclude tests/fixtures',
+                'expectedChanged' => array(
+                    'paths'    => array('.'),
+                    'excluded' => array(
+                        '.git',
+                        'node_modules',
+                        'tests/fixtures',
+                    ),
                 ),
             ),
             'Force enable colors' => array(
@@ -62,6 +105,13 @@ class SettingsParseArgumentsTest extends UnitTestCase
                 'expectedChanged' => array(
                     'excluded' => array('vendor'),
                     'colors'   => Settings::FORCED,
+                    'paths'    => array('.'),
+                ),
+            ),
+            'Force disable colors' => array(
+                'command'         => './parallel-lint --no-colors .',
+                'expectedChanged' => array(
+                    'colors'   => Settings::DISABLED,
                     'paths'    => array('.'),
                 ),
             ),
@@ -92,6 +142,40 @@ class SettingsParseArgumentsTest extends UnitTestCase
                 'expectedChanged' => array(
                     'format' => Settings::FORMAT_GITLAB,
                     'paths'  => array('.'),
+                ),
+            ),
+            'Custom path to git' => array(
+                'command'         => 'parallel-lint --git path/to/git.exe .',
+                'expectedChanged' => array(
+                    'gitExecutable' => 'path/to/git.exe',
+                    'paths'         => array('.'),
+                ),
+            ),
+            'Enable stdin' => array(
+                'command'         => 'parallel-lint --stdin',
+                'expectedChanged' => array(
+                    'stdin' => true,
+                ),
+            ),
+            'Enable blame' => array(
+                'command'         => 'parallel-lint --blame .',
+                'expectedChanged' => array(
+                    'blame' => true,
+                    'paths' => array('.'),
+                ),
+            ),
+            'Ignore failures' => array(
+                'command'         => 'parallel-lint --ignore-fails .',
+                'expectedChanged' => array(
+                    'ignoreFails' => true,
+                    'paths'       => array('.'),
+                ),
+            ),
+            'Show deprecations' => array(
+                'command'         => 'parallel-lint --show-deprecated .',
+                'expectedChanged' => array(
+                    'showDeprecated' => true,
+                    'paths'          => array('.'),
                 ),
             ),
             'Callback file' => array(


### PR DESCRIPTION
### SettingsParseArgumentsTest: refactor to dataprovider

Refactor the tests in the `SettingsParseArgumentsTest` class to use a data provider, which allow for adding more tests in a straight forward manner.

Includes expanding the actual tested settings values (values of the properties in the `Settings` class).
Previously, there were two tests which tested a range of property values, though still not all and multiple other tests which only verified one particular property value.

With the adjusted setup, all property values, except for the `phpExecutable`, will be tested for each and every test case.

Note: this is a 1-on-1 refactor of the test with all existing test cases still being tested but no other changes.

### SettingsParseArgumentsTest: add additional test cases

... to make sure all possible arguments handled by the `Settings::parseArguments()` method are covered by tests.

### SettingsParseArgumentsTest: add new test for handling of unsupported arguments

### SettingsParseArgumentsTest: add `@covers` tags