### PR TITLE
🔥 Hot fix: Fix PHAR not being compatible with PHP < 7.0 / Composer 2.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
           extensions: exif, phar, openssl
           coverage: none
           ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, zend.assertions=1
+          # Autoload files generated with Composer 2.3 are not compatible with PHP < 7.0.
+          tools: composer:2.2
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,8 @@ jobs:
           extensions: exif, phar, openssl
           coverage: none
           ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, zend.assertions=1
+          # Autoload files generated with Composer 2.3 are not compatible with PHP < 7.0.
+          tools: composer:2.2
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2


### PR DESCRIPTION
During builds, the PHAR file is generated and uploaded as an artefact to be used during the test job.
Along the same lines, the PHAR file is generated via a GH Actions workflow when a new version has been tagged and uploaded to the "Release".

Composer 2.3 has been released last week, which has a minimum PHP version of PHP 7.2 and the autoload files generated with Composer 2.3 are no longer compatible with PHP < 7.0.

Composer 2.2 (with a minimum PHP version of PHP 5.3) is now a LTS (long term service) release and will receive essential bug fixes.

The `setup-php` action runner will automatically install the appropriate version of Composer depending on the PHP version requested - Composer 2.2 for PHP < 7.2 and Composer 2.3+ for PHP 7.2+.

For the PHAR file, which is being generated on PHP 8.0 in the workflows, this means that Composer 2.3 is being installed and used to generate the PHAR file, which means that the autoload files generated with Composer 2.3 will be included, which makes the PHAR incompatible with PHP < 7.0.

To fix this, I'm adding a `tools` key to the `setup-php` action runner for the PHAR generation workflow which explicitly demands Composer 2.2.x, ensuring that the autoload files which will be included in the PHAR file will be compatible with PHP < 7.0.

Refs:
* https://blog.packagist.com/composer-2-3/
* https://github.com/composer/composer/releases


----

Note: I'm pulling this PR to `master` to ensure the PHARs for the `1.x` branch will be PHP cross-version compatible.

This commit should be cherry-picked to the `develop` branch (or I could open a separate PR for `develop`).