### PR TITLE
SyntaxError::getNormalizedMessage(): improve tests + 2 bug fixes

### DIFF
--- a/src/Errors/SyntaxError.php
+++ b/src/Errors/SyntaxError.php
@@ -30,7 +30,7 @@ class SyntaxError extends ParallelLintError
     public function getNormalizedMessage($translateTokens = false)
     {
         $message = preg_replace('~^(Parse|Fatal) error: (syntax error, )?~', '', $this->message);
-        $message = preg_replace('~ in ' . preg_quote(basename($this->filePath)) . ' on line [0-9]+$~', '', $message);
+        $message = preg_replace('~ in ' . preg_quote(basename($this->filePath), '~') . ' on line [0-9]+$~', '', $message);
         $message = ucfirst($message);
 
         if ($translateTokens) {

--- a/src/Errors/SyntaxError.php
+++ b/src/Errors/SyntaxError.php
@@ -31,7 +31,7 @@ class SyntaxError extends ParallelLintError
      */
     public function getNormalizedMessage($translateTokens = false)
     {
-        $message  = preg_replace('~^(Parse|Fatal) error: (syntax error, )?~', '', $this->message);
+        $message  = preg_replace('~^(?:Parse|Fatal) error: (?:syntax error, )?~', '', $this->message);
         $baseName = basename($this->filePath);
         $regex    = sprintf(self::IN_ON_REGEX, preg_quote($baseName, '~'));
         $message  = preg_replace($regex, '', $message, -1, $count);

--- a/tests/Unit/Errors/SyntaxErrorGetNormalizeMessageTest.php
+++ b/tests/Unit/Errors/SyntaxErrorGetNormalizeMessageTest.php
@@ -74,6 +74,10 @@ class SyntaxErrorGetNormalizeMessageTest extends UnitTestCase
                 'filePath' => 'test in file.php',
                 'fileName' => 'test in file.php',
             ),
+            'File name containing regex delimiter' => array(
+                'filePath' => 'test~file.php',
+                'fileName' => 'test~file.php',
+            ),
         );
     }
 }

--- a/tests/Unit/Errors/SyntaxErrorGetNormalizeMessageTest.php
+++ b/tests/Unit/Errors/SyntaxErrorGetNormalizeMessageTest.php
@@ -20,7 +20,7 @@ class SyntaxErrorGetNormalizeMessageTest extends UnitTestCase
      *
      * @return void
      */
-    public function testMessageNormalization($message, $expected)
+    public function testMessageNormalizationWithoutTokenTranslation($message, $expected)
     {
         $error = new SyntaxError('test.php', $message);
         $this->assertSame($expected, $error->getNormalizedMessage());
@@ -34,11 +34,33 @@ class SyntaxErrorGetNormalizeMessageTest extends UnitTestCase
     public function dataMessageNormalization()
     {
         return array(
-            'Strip leading and trailing information' => array(
+            'Strip leading and trailing information - fatal error' => array(
                 'message'  => "Fatal error: 'break' not in the 'loop' or 'switch' context in test.php on line 2",
                 'expected' => "'break' not in the 'loop' or 'switch' context",
             ),
+            'Strip leading and trailing information - parse error' => array(
+                'message'  => "Parse error: unexpected 'Foo' (T_STRING) in test.php on line 2",
+                'expected' => "Unexpected 'Foo' (T_STRING)", // Also verifies ucfirst() call is being made.
+            ),
+            'Strip trailing information, not leading - deprecation' => array(
+                'message'  => "Deprecated: The (real) cast is deprecated, use (float) instead in test.php on line 2",
+                'expected' => "Deprecated: The (real) cast is deprecated, use (float) instead",
+            ),
         );
+    }
+
+    /**
+     * Test retrieving a normalized error message with token translation.
+     *
+     * @return void
+     */
+    public function testMessageNormalizationWithTokenTranslation()
+    {
+        $message  = 'Parse error: unexpected T_FILE, expecting T_STRING in test.php on line 2';
+        $expected = 'Unexpected __FILE__ (T_FILE), expecting T_STRING';
+
+        $error = new SyntaxError('test.php', $message);
+        $this->assertSame($expected, $error->getNormalizedMessage(true));
     }
 
     /**

--- a/tests/Unit/Errors/SyntaxErrorGetNormalizeMessageTest.php
+++ b/tests/Unit/Errors/SyntaxErrorGetNormalizeMessageTest.php
@@ -78,6 +78,26 @@ class SyntaxErrorGetNormalizeMessageTest extends UnitTestCase
                 'filePath' => 'test~file.php',
                 'fileName' => 'test~file.php',
             ),
+            'Full file path, linux slashes' => array(
+                'filePath' => 'path/to/subdir/file.php',
+                'fileName' => 'file.php',
+            ),
+            'File path, windows slashes' => array(
+                'filePath' => 'path\to\subdir\file.php',
+                'fileName' => 'file.php',
+            ),
+            'Absolute file path, windows slashes' => array(
+                'filePath' => 'C:\path\to\subdir\file.php',
+                'fileName' => 'C:\path\to\subdir\file.php',
+            ),
+            'Relative file path, windows slashes' => array(
+                'filePath' => '.\subdir\file.php',
+                'fileName' => '.\subdir\file.php',
+            ),
+            'Phar file name' => array(
+                'filePath' => 'phar://031.phar.php/a.php',
+                'fileName' => 'phar://031.phar.php/a.php',
+            ),
         );
     }
 }


### PR DESCRIPTION
### SyntaxErrorGetNormalizeMessageTest: refactor to dataprovider

Refactor the tests in the `SyntaxErrorGetNormalizeMessageTest` class to use data providers, which allow for adding more tests in a straight forward manner.

Note: this is a 1-on-1 refactor of the test with all existing test cases still being tested but no other changes.

### SyntaxError::getNormalizedMessage(): bug fix - file name containing regex delimiter

If a file name would contain the delimiter used in the replacement regex, it would cause a PHP error like `preg_replace(): Unknown modifier 'f'`.

Fixed by telling `preg_quote()` explicitly which delimiter is being used.

Includes unit test.

Ref: https://www.php.net/manual/en/function.preg-quote.php

### SyntaxError::getNormalizedMessage(): bug fix - "in file on line" doesn't always get stripped

In certain cases, PHP puts the full file name in the error message. In those cases the "in filename.php on line .." trailing part of the error message did not get stripped off.

Also, in some cases, when Windows slashes are used in the file path, the "in filename.php on line .." trailing part of the error message may not get stripped off.
This last case will be exceedingly rare as on Windows, those file paths are handled correctly and the chances of a non-Windows user passing a path using Windows slashes will be minuscule.

Even so, I've fixed both cases by making the path handling in the function more robust.
* When the initial stripping of the trailing part of the error message fails, it will be retried up to two times.
* The first time, if Windows slashes would be found in the file path _after_ the `basename()` function has been applied, a "manual" basename extraction is done and the stripping of the trailing part is retried.
* The second time, the full file path is used in a last attempt to strip the trailing part of the error message.

Includes unit tests.

Fixes #94

### SyntaxErrorGetNormalizeMessageTest: add some additional test cases

Including documenting that a `Deprecated:` prefix will not be removed.

### SyntaxError::getNormalizedMessage(): minor regex tweak

By using `?:` at the start of a parenthesis group, the group will not be "remembered"/saved to memory.

As this regex does not use the subgroups anyway, we don't need to remember them.