### PR TITLE
GH Actions: updates for box 4.x (`develop`)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
-          extensions: exif, phar, openssl
+          php-version: 8.1
+          extensions: exif, phar, openssl, sodium
           coverage: none
           ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, zend.assertions=1
           # Autoload files generated with Composer 2.3 are not compatible with PHP < 7.0.
@@ -40,6 +40,8 @@ jobs:
         with:
           composer-options: "--no-dev"
 
+      # Note: do NOT turn on the requirement checker in the box config as it is no longer
+      # compatible with PHP < 7.2.
       - name: Install Box
         run: wget https://github.com/humbug/box/releases/latest/download/box.phar -O box.phar && chmod 0755 box.phar && pwd
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
-          extensions: exif, phar, openssl
+          php-version: 8.1
+          extensions: exif, phar, openssl, sodium
           coverage: none
           ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, zend.assertions=1
           # Autoload files generated with Composer 2.3 are not compatible with PHP < 7.0.
@@ -63,6 +63,8 @@ jobs:
         with:
           composer-options: "--no-dev"
 
+      # Note: do NOT turn on the requirement checker in the box config as it is no longer
+      # compatible with PHP < 7.2.
       - name: Install Box
         run: wget https://github.com/humbug/box/releases/latest/download/box.phar -O box.phar && chmod 0755 box.phar && pwd
 


### PR DESCRIPTION
Sister-PR to #121.


The box project has released Box 4.0.0 (and 4.0.1).

Most notable changes:
* New minimum PHP version of PHP 8.1.
* The sodium extension has become a requirement.
* The requirements checker now has a minimum PHP version of PHP 7.2.4.

We already disabled the requirements checker previously due to PHP 8.1 incompatibilities (PR #70), I've now added a comment to document not to turn it on again as that would make the Parallel Lint PHAR incompatible with PHP < 7.2.

Refs: https://github.com/box-project/box/releases/tag/4.0.0