### PR TITLE
Add box.json back to release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,6 @@
 .gitattributes   export-ignore
 .gitignore       export-ignore
 appveyor.yml     export-ignore
-box.json         export-ignore
 phpcs.xml.dist   export-ignore
 phpunit.xml.dist export-ignore
 /.github/        export-ignore


### PR DESCRIPTION
I use this to build phar in my infra:

```sh
    cd vendor/php-parallel-lint/php-parallel-lint
      box build -c box.json -v
      chmod a+rx ./*.phar
    cd -
    mv vendor/php-parallel-lint/php-parallel-lint/*.phar .
    ./parallel-lint.phar
```