### PR TITLE
GH Actions: use `fail-fast` with setup-php when creating the binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
           ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, zend.assertions=1
           # Autoload files generated with Composer 2.3 are not compatible with PHP < 7.0.
           tools: composer:2.2
+          fail-fast: true
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,7 @@ jobs:
           ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, zend.assertions=1
           # Autoload files generated with Composer 2.3 are not compatible with PHP < 7.0.
           tools: composer:2.2
+          fail-fast: true
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2


### PR DESCRIPTION
The recent build failure was due to the `setup-php` action running into a rate limit and not downloading the required version of Composer (`2.2`), which meant that the PHAR ended up being build with Composer 2.4.

The `setup-php` action runner defaults to _showing_ these type errors in the logs, but not stopping the workflow run.

For the creation of the binary it is really important that the correct Composer version is used as otherwise the PHAR file won't be compatible with PHP 5.3 - 5.5.

So, specifically for those jobs, I'm adding the `fail-fast` option to `setup-php` to fail the build if the action runner ran into any errors.

Ref: https://github.com/shivammathur/setup-php#fail-fast-optional