### PR TITLE
DX: Add composer keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,10 @@
     "description": "This tool check syntax of PHP files about 20x faster than serial check.",
     "homepage": "https://github.com/php-parallel-lint/PHP-Parallel-Lint",
     "license": "BSD-2-Clause",
+    "keywords": [
+        "lint",
+        "static analysis"
+    ],
     "authors": [
         {
             "name": "Jakub Onderka",


### PR DESCRIPTION
as per https://github.com/composer/composer/pull/10960 this allows composer to warn the user, when installing the tool as a project dependency instead of a dev-dependency