### PR TITLE
Implement faster FilteredRecursiveDirectoryIterator

### DIFF
--- a/src/Iterators/FilteredRecursiveDirectoryIterator.php
+++ b/src/Iterators/FilteredRecursiveDirectoryIterator.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PHP_Parallel_Lint\PhpParallelLint\Iterators;
+
+use ReturnTypeWillChange;
+
+class FilteredRecursiveDirectoryIterator extends \RecursiveDirectoryIterator
+{
+    private $excluded = array();
+
+    public function __construct($path, $flags = null, array $excluded = array())
+    {
+        $this->excluded = $excluded;
+
+        if ($flags === null) {
+            $flags = \FilesystemIterator::KEY_AS_PATHNAME | \FilesystemIterator::CURRENT_AS_FILEINFO;
+        }
+
+        parent::__construct($path, $flags);
+    }
+
+    #[ReturnTypeWillChange]
+    public function hasChildren($allowLinks = false)
+    {
+        if (in_array($this->getBasename(), $this->excluded)) {
+            return false;
+        }
+
+        return parent::hasChildren($allowLinks);
+    }
+}

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -9,6 +9,7 @@ use PHP_Parallel_Lint\PhpParallelLint\Exceptions\CallbackNotImplementedException
 use PHP_Parallel_Lint\PhpParallelLint\Exceptions\ClassNotFoundException;
 use PHP_Parallel_Lint\PhpParallelLint\Exceptions\ParallelLintException;
 use PHP_Parallel_Lint\PhpParallelLint\Exceptions\PathNotFoundException;
+use PHP_Parallel_Lint\PhpParallelLint\Iterators\FilteredRecursiveDirectoryIterator;
 use PHP_Parallel_Lint\PhpParallelLint\Iterators\RecursiveDirectoryFilterIterator;
 use PHP_Parallel_Lint\PhpParallelLint\Outputs\CheckstyleOutput;
 use PHP_Parallel_Lint\PhpParallelLint\Outputs\GitLabOutput;
@@ -163,7 +164,7 @@ class Manager
             if (is_file($path)) {
                 $files[] = $path;
             } elseif (is_dir($path)) {
-                $iterator = new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS);
+                $iterator = new FilteredRecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS, $excluded);
                 if (!empty($excluded)) {
                     $iterator = new RecursiveDirectoryFilterIterator($iterator, $excluded);
                 }


### PR DESCRIPTION
closes https://github.com/php-parallel-lint/PHP-Parallel-Lint/issues/135

running parallel lint in https://github.com/FriendsOfREDAXO/rexstan with `vendor/bin/parallel-lint . --exclude vendor` takes `0.3 seconds` with this PR while it took `9 seconds` before the PR

