### PR TITLE
Align the percentage output

### DIFF
--- a/src/Outputs/TextOutput.php
+++ b/src/Outputs/TextOutput.php
@@ -194,9 +194,9 @@ class TextOutput implements OutputInterface
 
     protected function writePercent()
     {
-        $percent = floor($this->checkedFiles / $this->totalFileCount * 100);
+        $percent = $this->stringWidth(floor($this->checkedFiles / $this->totalFileCount * 100), 3);
         $current = $this->stringWidth($this->checkedFiles, strlen($this->totalFileCount));
-        $this->writeLine(" $current/$this->totalFileCount ($percent %)");
+        $this->writeLine(" $current/$this->totalFileCount ($percent%)");
     }
 
     /**


### PR DESCRIPTION
Left pad with whitespace so that the 100% line doesn't pop out of alignment.

Before:
```
............................................................  60/337 (17 %)
............................................................ 120/337 (35 %)
............................................................ 180/337 (53 %)
............................................................ 240/337 (71 %)
............................................................ 300/337 (89 %)
.....................................                        337/337 (100 %)
```

After:
```
............................................................  60/337 ( 17%)
............................................................ 120/337 ( 35%)
............................................................ 180/337 ( 53%)
............................................................ 240/337 ( 71%)
............................................................ 300/337 ( 89%)
.....................................                        337/337 (100%)
```