### PR TITLE
Fix unit tests in master branch - unit tests library issue

### DIFF
--- a/tests/Manager.run.phpt
+++ b/tests/Manager.run.phpt
@@ -6,6 +6,8 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
+Tester\Environment::setup();
+
 use JakubOnderka\PhpParallelLint\Manager;
 use JakubOnderka\PhpParallelLint\NullWriter;
 use JakubOnderka\PhpParallelLint\Settings;

--- a/tests/Output.phpt
+++ b/tests/Output.phpt
@@ -6,6 +6,8 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
+Tester\Environment::setup();
+
 use JakubOnderka\PhpParallelLint\ErrorFormatter;
 use JakubOnderka\PhpParallelLint\GitLabOutput;
 use JakubOnderka\PhpParallelLint\CheckstyleOutput;

--- a/tests/ParallelLint.lint.phpt
+++ b/tests/ParallelLint.lint.phpt
@@ -6,6 +6,8 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
+Tester\Environment::setup();
+
 use JakubOnderka\PhpParallelLint\ParallelLint;
 use Tester\Assert;
 

--- a/tests/Settings.parseArguments.phpt
+++ b/tests/Settings.parseArguments.phpt
@@ -6,6 +6,8 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
+Tester\Environment::setup();
+
 use JakubOnderka\PhpParallelLint\Settings;
 use Tester\Assert;
 

--- a/tests/Settings.parseArguments.phpt
+++ b/tests/Settings.parseArguments.phpt
@@ -59,7 +59,7 @@ class SettingsParseArgumentsTest extends Tester\TestCase
         $expectedSettings->colors = Settings::DISABLED;
         $expectedSettings->showProgress = true;
         $expectedSettings->format = Settings::FORMAT_TEXT;
-        $expectedSettings->deprecated = false;
+        $expectedSettings->showDeprecated = false;
 
         Assert::equal($expectedSettings->shortTag, $settings->shortTag);
         Assert::equal($expectedSettings->aspTags, $settings->aspTags);

--- a/tests/SkipLintProcess.phpt
+++ b/tests/SkipLintProcess.phpt
@@ -6,6 +6,8 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
+Tester\Environment::setup();
+
 use Tester\Assert;
 
 class SkipLintProcessTest extends Tester\TestCase

--- a/tests/SyntaxError.normalizeMessage.phpt
+++ b/tests/SyntaxError.normalizeMessage.phpt
@@ -6,6 +6,8 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
+Tester\Environment::setup();
+
 use JakubOnderka\PhpParallelLint\SyntaxError;
 use Tester\Assert;
 


### PR DESCRIPTION
I changed description ~15min after creating a PR. PR solve 2 issues:

**1. issue with Nette Tester**
Is necesary setup library for PHP unit tests.

Library Nette Tester is used of 1.x version (on master branch). 
[An error](https://github.com/nette/tester/pull/442) in Nette Tester is the reason for failing unit tests.

This PR will not be pushed to `develop` branch. It used PHPUnit library.

**2. issue with incorrect property name**
Second commit resolve issue with missing property. Mistake comes from https://github.com/JakubOnderka/PHP-Parallel-Lint/pull/94/files#diff-0f72a4d5de7cb5a661be1a8151dc9a3c0c38d7dd00b005f0c1ce39082021872aR61 that is a typo.