### PR TITLE
Skip shebang sequence if it is the first line

### DIFF
--- a/bin/skip-linting.php
+++ b/bin/skip-linting.php
@@ -9,6 +9,12 @@ foreach (explode(PHP_EOL, $input) as $file) {
     $f = @fopen($file, 'r');
     if ($f) {
         $firstLine = fgets($f);
+
+        // ignore shebang line
+        if (strpos($firstLine, '#!') === 0) {
+            $firstLine = fgets($f);
+        }
+
         @fclose($f);
 
         if (preg_match('~<?php\\s*\\/\\/\s*lint\s*([^\d\s]+)\s*([^\s]+)\s*~i', $firstLine, $m)) {

--- a/tests/Unit/ParallelLintLintTest.php
+++ b/tests/Unit/ParallelLintLintTest.php
@@ -78,6 +78,16 @@ class ParallelLintLintTest extends UnitTestCase
         $this->assertSame(0, count($result->getErrors()));
     }
 
+    public function testSkipShebang()
+    {
+        $parallelLint = new ParallelLint($this->getPhpExecutable());
+        $result = $parallelLint->lint(array(PL_TESTROOT . '/fixtures/fixture-07/example.php'));
+
+        $this->assertSame(0, $result->getCheckedFilesCount());
+        $this->assertSame(0, $result->getFilesWithSyntaxErrorCount());
+        $this->assertSame(1, $result->getSkippedFilesCount());
+    }
+
     public function testInvalidFile()
     {
         $parallelLint = new ParallelLint($this->getPhpExecutable());

--- a/tests/fixtures/fixture-07/example.php
+++ b/tests/fixtures/fixture-07/example.php
@@ -1,0 +1,5 @@
+#!/usr/bin/php
+<?php // lint < 5.3
+
+$myString = 'This is always skipped';
+echo $myString;


### PR DESCRIPTION
When linting executable files the first line is not always the php opening tag.

On such occasions we need to skip the shebang line, and read next line.