### PR TITLE
escape binary php path

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -38,12 +38,7 @@ class Manager
         $settings = $settings ?: new Settings();
         $output = $this->output ?: $this->getDefaultOutput($settings);
 
-        $settingsPhpExecutable = escapeshellarg($settings->phpExecutable);
-        if (stripos(PHP_OS, 'WIN') === 0) {
-            $settingsPhpExecutable = preg_replace('`(?<!^) `', '^ ', escapeshellcmd($settings->phpExecutable));
-        }
-
-        $phpExecutable = PhpExecutable::getPhpExecutable($settingsPhpExecutable);
+        $phpExecutable = PhpExecutable::getPhpExecutable(escapeshellarg($settings->phpExecutable));
         $olderThanPhp54 = $phpExecutable->getVersionId() < 50400; // From PHP version 5.4 are tokens translated by default
         $translateTokens = $phpExecutable->isIsHhvmType() || $olderThanPhp54;
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -38,7 +38,7 @@ class Manager
         $settings = $settings ?: new Settings();
         $output = $this->output ?: $this->getDefaultOutput($settings);
 
-        $phpExecutable = PhpExecutable::getPhpExecutable($settings->phpExecutable);
+        $phpExecutable = PhpExecutable::getPhpExecutable(escapeshellarg($settings->phpExecutable));
         $olderThanPhp54 = $phpExecutable->getVersionId() < 50400; // From PHP version 5.4 are tokens translated by default
         $translateTokens = $phpExecutable->isIsHhvmType() || $olderThanPhp54;
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -38,7 +38,12 @@ class Manager
         $settings = $settings ?: new Settings();
         $output = $this->output ?: $this->getDefaultOutput($settings);
 
-        $phpExecutable = PhpExecutable::getPhpExecutable(escapeshellarg($settings->phpExecutable));
+        $settingsPhpExecutable = escapeshellarg($settings->phpExecutable);
+        if (stripos(PHP_OS, 'WIN') === 0) {
+            $settingsPhpExecutable = preg_replace('`(?<!^) `', '^ ', escapeshellcmd($settings->phpExecutable));
+        }
+
+        $phpExecutable = PhpExecutable::getPhpExecutable($settingsPhpExecutable);
         $olderThanPhp54 = $phpExecutable->getVersionId() < 50400; // From PHP version 5.4 are tokens translated by default
         $translateTokens = $phpExecutable->isIsHhvmType() || $olderThanPhp54;
 


### PR DESCRIPTION
This PR allows to fix php executable path when path like this : 
`/Users/xxxx/Application Support/Herd/bin/php82`

Without escaping, binary was not executable because it stop to `/Users/xxx/Application`