### PR TITLE
Escape spaces in PHP binary path

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -130,7 +130,7 @@ class Settings
 
         // Use the currently invoked php as the default if possible
         if (defined('PHP_BINARY')) {
-            $settings->phpExecutable = str_replace(' ', '\ ', PHP_BINARY);
+            $settings->phpExecutable = self::escapeString(PHP_BINARY);
         }
 
         foreach ($arguments as $argument) {
@@ -234,6 +234,22 @@ class Settings
 
         $lines = explode("\n", rtrim($content));
         return array_map('rtrim', $lines);
+    }
+
+    /**
+     * @param string $path
+     * @param string $os
+     * @return string
+     */
+    public static function escapeString(string $path, string $os = PHP_OS)
+    {
+        if (stripos(strtoupper($os), 'WIN') === 0) {
+            $path = str_replace('^\\', '\\',  preg_replace('`(?<!^) `', '^ ', escapeshellcmd($path)));
+        } else {
+            $path = preg_replace('`(?<!\\\) `', '\ ', escapeshellcmd($path));
+        }
+
+        return $path;
     }
 }
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -243,6 +243,8 @@ class Settings
      */
     public static function escapeString(string $path, string $os = PHP_OS)
     {
+        $path = trim($path);
+
         if (stripos(strtoupper($os), 'WIN') === 0) {
             $path = str_replace('^\\', '\\',  preg_replace('`(?<!^) `', '^ ', escapeshellcmd($path)));
         } else {

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -130,7 +130,7 @@ class Settings
 
         // Use the currently invoked php as the default if possible
         if (defined('PHP_BINARY')) {
-            $settings->phpExecutable = PHP_BINARY;
+            $settings->phpExecutable = str_replace(' ', '\ ', PHP_BINARY);
         }
 
         foreach ($arguments as $argument) {

--- a/tests/Settings.parseArguments.phpt
+++ b/tests/Settings.parseArguments.phpt
@@ -144,6 +144,22 @@ class SettingsParseArgumentsTest extends Tester\TestCase
 
         Assert::equal($expectedSettings->syntaxErrorCallbackFile, $settings->syntaxErrorCallbackFile);
     }
+
+    public function testEscapingPathForUnixSystems()
+    {
+        Settings::escapeString('path with spaces');
+
+        $php_path = "path with/spaces between/php.exe";
+        Assert::equal(Settings::escapeString($php_path, 'Darwin'), "path\\ with/spaces\\ between/php.exe");
+    }
+
+    public function testEscapingPathForWindows()
+    {
+        Settings::escapeString('path with spaces');
+
+        $php_path = "path with\spaces between\php.exe";
+        Assert::equal(Settings::escapeString($php_path, 'Windows'), 'path^ with\\\spaces^ between\\\php.exe');
+    }
 }
 
 $testCase = new SettingsParseArgumentsTest;

--- a/tests/Settings.parseArguments.phpt
+++ b/tests/Settings.parseArguments.phpt
@@ -160,6 +160,25 @@ class SettingsParseArgumentsTest extends Tester\TestCase
         $php_path = "path with\spaces between\php.exe";
         Assert::equal(Settings::escapeString($php_path, 'Windows'), 'path^ with\\\spaces^ between\\\php.exe');
     }
+
+    public function testEscapingEmptyPath()
+    {
+        Assert::equal(Settings::escapeString(''), '');
+    }
+
+    public function testEscapingPathWithSpecialChars()
+    {
+        $path = "path/with/special&characters";
+
+        Assert::equal(Settings::escapeString($path), "path/with/special\&characters");
+    }
+
+    public function testEscapingPathWithLeadingTrailingSpaces()
+    {
+        $path = "  path with\spaces  ";
+
+        Assert::equal(Settings::escapeString($path), "path\\ with\\\spaces");
+    }
 }
 
 $testCase = new SettingsParseArgumentsTest;


### PR DESCRIPTION
This PR escapes spaces in binary path.

When you have space in your PHP binary path (Ex: /**/Library/Application Support/Herd/bin/php82'). I get an error output:
```
Unable to execute '/Users/user/Library/Application Support/Herd/bin/php82'.
```