### PR TITLE
GH Actions: update PHP version for PHAR boxing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           extensions: exif, phar, openssl, sodium
           coverage: none
           ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, zend.assertions=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           extensions: exif, phar, openssl, sodium
           coverage: none
           ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, zend.assertions=1


### PR DESCRIPTION
Looks like Box silently dropped support for PHP 8.1. Upgrading the version on which Box is run to 8.2 should fix this. The resulting PHAR files should still work fine on PHP < 8.2.

Ref: https://github.com/box-project/box/releases

Note: this commit will need to be back-ported to the `master` branch to get passing builds there again too.