### PR TITLE
[PHP 8.4] Fixes for implicit nullability deprecation

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -33,9 +33,9 @@ class Manager
      * @return Result
      * @throws ParallelLintException
      */
-    public function run(?Settings $settings = null)
+    public function run($settings = null)
     {
-        $settings = $settings ?: new Settings();
+        $settings = ($settings instanceof Settings) ? $settings : new Settings();
         $output = $this->output ?: $this->getDefaultOutput($settings);
 
         $phpExecutable = PhpExecutable::getPhpExecutable($settings->phpExecutable);

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -33,7 +33,7 @@ class Manager
      * @return Result
      * @throws ParallelLintException
      */
-    public function run(Settings $settings = null)
+    public function run(?Settings $settings = null)
     {
         $settings = $settings ?: new Settings();
         $output = $this->output ?: $this->getDefaultOutput($settings);


### PR DESCRIPTION
Fixes all issues that emit deprecation notices on PHP 8.4 for implicit nullable parameter type declarations.

See:
 - [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
 - [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)