### PR TITLE
OutputTest: fix risky test

### DIFF
--- a/tests/Unit/Outputs/OutputTest.php
+++ b/tests/Unit/Outputs/OutputTest.php
@@ -26,6 +26,8 @@ class OutputTest extends UnitTestCase
 
         $result = (array) json_decode($writer->getLogs());
 
+        $this->assertSame(count($errors), count($result));
+
         for ($i = 0; $i < count($result) && $i < count($errors); $i++) {
             $message = $errors[$i]->getMessage();
             $filePath = $errors[$i]->getFilePath();


### PR DESCRIPTION
The `OutputTest::testGitLabOutput()` was being marked as risky for the first test case (no errors) as no assertions were being run.

This commit adds an extra assertion to prevent this, but also to make the test more thorough as the test will now also fail if the number of errors expected versus received does not match.