### PR TITLE
2.0 | Make tests compatible with PHPUnit 10

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,15 +5,16 @@
 # https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
 # https://blog.madewithlove.be/post/gitattributes/
 #
-.gitattributes   export-ignore
-.gitignore       export-ignore
-appveyor.yml     export-ignore
-box.json         export-ignore
-phpcs.xml.dist   export-ignore
-phpunit.xml.dist export-ignore
-/.github/        export-ignore
-/doc/            export-ignore
-/tests/          export-ignore
+.gitattributes     export-ignore
+.gitignore         export-ignore
+appveyor.yml       export-ignore
+box.json           export-ignore
+phpcs.xml.dist     export-ignore
+phpunit.xml.dist   export-ignore
+phpunit10.xml.dist export-ignore
+/.github/          export-ignore
+/doc/              export-ignore
+/tests/            export-ignore
 
 #
 # Auto detect text files and perform LF normalization

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,8 +152,17 @@ jobs:
       - name: 'Integration test 2 - linting own code'
         run: ./parallel-lint --exclude vendor --exclude tests/fixtures .
 
-      - name: 'Run unit tests'
+      - name: Grab PHPUnit version
+        id: phpunit_version
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+
+      - name: "Run unit tests (PHPUnit < 10)"
+        if: ${{ ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
         run: composer test
+
+      - name: "Run unit tests (PHPUnit < 10)"
+        if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
+        run: composer test10
 
       - uses: actions/download-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 phpcs.xml
 .phpunit.result.cache
 phpunit.xml
+phpunit10.xml

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "jakub-onderka/php-parallel-lint": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.1",
         "php-parallel-lint/php-console-highlighter": "0.* || ^1.0",
         "php-parallel-lint/php-code-style": "^2.0"
     },
@@ -50,10 +50,14 @@
     ],
     "scripts": {
         "test": "@php ./vendor/phpunit/phpunit/phpunit --no-coverage",
-        "coverage": "@php ./vendor/phpunit/phpunit/phpunit"
+        "test10": "@php ./vendor/phpunit/phpunit/phpunit -c phpunit10.xml.dist --no-coverage",
+        "coverage": "@php ./vendor/phpunit/phpunit/phpunit",
+        "coverage10": "@php ./vendor/phpunit/phpunit/phpunit -c phpunit10.xml.dist"
     },
     "scripts-descriptions": {
-        "test": "Run all tests!",
-        "coverage": "Run all tests *with code coverage*"
+        "test": "Run all tests! ( PHPUnit < 10)",
+        "test10": "Run all tests! ( PHPUnit 10+)",
+        "coverage": "Run all tests *with code coverage* ( PHPUnit < 10)",
+        "coverage10": "Run all tests *with code coverage* ( PHPUnit 10+)"
     }
 }

--- a/phpunit10.xml.dist
+++ b/phpunit10.xml.dist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+        backupGlobals="true"
+        beStrictAboutTestsThatDoNotTestAnything="true"
+        bootstrap="./tests/bootstrap.php"
+        colors="true"
+        displayDetailsOnTestsThatTriggerErrors="true"
+        displayDetailsOnTestsThatTriggerWarnings="true"
+        displayDetailsOnTestsThatTriggerNotices="true"
+        displayDetailsOnTestsThatTriggerDeprecations="true"
+        displayDetailsOnIncompleteTests="true"
+        displayDetailsOnSkippedTests="true"
+        failOnWarning="true"
+        failOnNotice="true"
+        failOnDeprecation="true"
+        stopOnFailure="false"
+    >
+
+    <testsuites>
+        <testsuite name="Unittests">
+            <directory suffix="Test.php">tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory suffix=".php">./src/</directory>
+        </include>
+    </source>
+
+    <coverage includeUncoveredFiles="true" ignoreDeprecatedCodeUnits="true">
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+            <text outputFile="php://stdout" showOnlySummary="true"/>
+        </report>
+    </coverage>
+
+</phpunit>

--- a/tests/Unit/Errors/ParallelLintErrorTest.php
+++ b/tests/Unit/Errors/ParallelLintErrorTest.php
@@ -31,7 +31,7 @@ class ParallelLintErrorTest extends UnitTestCase
      *
      * @return array
      */
-    public function dataGetMessage()
+    public static function dataGetMessage()
     {
         return array(
             'Message: empty string' => array(
@@ -88,7 +88,7 @@ class ParallelLintErrorTest extends UnitTestCase
      *
      * @return array
      */
-    public function dataGetFilePath()
+    public static function dataGetFilePath()
     {
         $cwd = getcwd();
 

--- a/tests/Unit/Errors/SyntaxErrorGetLineTest.php
+++ b/tests/Unit/Errors/SyntaxErrorGetLineTest.php
@@ -31,7 +31,7 @@ class SyntaxErrorGetLineTest extends UnitTestCase
      *
      * @return array
      */
-    public function dataGetLine()
+    public static function dataGetLine()
     {
         return array(
             'Message: empty string' => array(

--- a/tests/Unit/Errors/SyntaxErrorGetNormalizeMessageTest.php
+++ b/tests/Unit/Errors/SyntaxErrorGetNormalizeMessageTest.php
@@ -31,7 +31,7 @@ class SyntaxErrorGetNormalizeMessageTest extends UnitTestCase
      *
      * @return array
      */
-    public function dataMessageNormalization()
+    public static function dataMessageNormalization()
     {
         return array(
             'Strip leading and trailing information - fatal error' => array(
@@ -85,7 +85,7 @@ class SyntaxErrorGetNormalizeMessageTest extends UnitTestCase
      *
      * @return array
      */
-    public function dataFilePathHandling()
+    public static function dataFilePathHandling()
     {
         return array(
             'Plain file name' => array(

--- a/tests/Unit/Errors/SyntaxErrorTranslateTokensTest.php
+++ b/tests/Unit/Errors/SyntaxErrorTranslateTokensTest.php
@@ -31,7 +31,7 @@ class SyntaxErrorTranslateTokensTest extends UnitTestCase
      *
      * @return array
      */
-    public function dataTranslateTokens()
+    public static function dataTranslateTokens()
     {
         return array(
             'No token name in message' => array(

--- a/tests/Unit/Outputs/OutputTest.php
+++ b/tests/Unit/Outputs/OutputTest.php
@@ -68,7 +68,7 @@ class OutputTest extends UnitTestCase
         $this->assertInstanceOf('SimpleXMLElement', $parsed);
     }
 
-    public function getGitLabOutputData()
+    public static function getGitLabOutputData()
     {
         return array(
             array(

--- a/tests/Unit/SettingsAddPathsTest.php
+++ b/tests/Unit/SettingsAddPathsTest.php
@@ -36,7 +36,7 @@ class SettingsAddPathsTest extends UnitTestCase
      *
      * @return array
      */
-    public function dataAddPaths()
+    public static function dataAddPaths()
     {
         return array(
             'No paths passed on CLI, no extra paths' => array(

--- a/tests/Unit/SettingsParseArgumentsTest.php
+++ b/tests/Unit/SettingsParseArgumentsTest.php
@@ -35,7 +35,7 @@ class SettingsParseArgumentsTest extends UnitTestCase
      *
      * @return array
      */
-    public function dataParseArgumentsInvalidArgument()
+    public static function dataParseArgumentsInvalidArgument()
     {
         return array(
             'Unsupported short argument' => array(
@@ -79,7 +79,7 @@ class SettingsParseArgumentsTest extends UnitTestCase
      *
      * @return array
      */
-    public function dataParseArguments()
+    public static function dataParseArguments()
     {
         return array(
             'No arguments at all' => array(


### PR DESCRIPTION
### Tests: make dataproviders static

As of PHPUnit 10, data providers are (again) expected to be `static` methods.

This updates the test suite to respect that.

Includes removing the use of `$this` from select data providers.

Refs:
* sebastianbergmann/phpunit@9caafe2
* sebastianbergmann/phpunit#5100

### PHPUnit: allow for PHPUnit 10 + add separate configuration

The PHPunit configuration file specification has undergone changes in PHPUnit 9.3, 10.0 and 10.1.

Most notably:
* In PHPUnit 9.3, the manner of specifying the code coverage configuration has changed.
* In PHPUnit 10.0, a significant number of attributes of the `<phpunit>` element were removed or renamed.
* In PHPUnit 10.1, there is another change related to the code coverage configuration + the ability to fail builds on deprecations/warnings/notices is brought back.

While the `--migrate-configuration` command can upgrade a configuration for the changes in the format made in PHPUnit 9.3, some of the changes in the configuration format in PHPUnit 10 don't have one-on-one replacements and/or are not taken into account.

As this package is used in the CI pipeline for other packages, it is important for this package to be ready for new PHP releases _early_, so failing the test suite on deprecatios/notices and warnings is appropriate.

With that in mind, I deem it more appropriate to have a dedicated PHPUnit configuration file for PHPUnit 10 to ensure the test run will behave as intended.

This commit adds this dedicated configuration file for PHPUnit 10.1+.

Includes:
* Ignoring the new file for package archives.
* Allowing for a local override file.
* Adding scripts to the `composer.json` file to run the tests using this new configuration file and make the use of the separate config make more obvious for contributors.
* Updating the GH Actions `test` workflow to trigger the tests on PHPUnit 10 with this configuration file.

Ref:
* https://github.com/sebastianbergmann/phpunit/blob/main/ChangeLog-10.0.md#1000---2023-02-03
* sebastianbergmann/phpunit#5196
* https://github.com/sebastianbergmann/phpunit/commit/fb6673f06ef90b43667b7187722e2c840dcdb573

---

Note: while PHPUnit 11 has come out in the mean time as well, making the test suite compatible with that should wait for a while as we'll need PHPUnit 11.1 (expected April 5th) as a minimum and will need to make significant other changes to the tests, like splitting test classes based on what the tests cover, before we can start running the tests on PHPUnit 11.