### PR TITLE
GH Actions: version update for various predefined actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -38,7 +38,7 @@ jobs:
           fail-fast: true
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
         with:
           composer-options: "--no-dev"
           # Bust the cache at least once a month - output format: YYYY-MM.
@@ -58,7 +58,7 @@ jobs:
       - name: Show info about the build phar with box-project/box
         run: php box.phar info -l parallel-lint.phar
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: parallel-lint-phar
           path: ./parallel-lint.phar
@@ -89,9 +89,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: parallel-lint-phar
 
@@ -113,7 +113,7 @@ jobs:
       - verify
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: parallel-lint-phar
 
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload Phar as Release Asset
         id: upload-release-asset
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,10 @@ jobs:
           tools: cs2pr
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -65,7 +65,7 @@ jobs:
           fail-fast: true
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
         with:
           composer-options: "--no-dev"
           # Bust the cache at least once a month - output format: YYYY-MM.
@@ -85,7 +85,7 @@ jobs:
       - name: Show info about the build phar with box-project/box
         run: php box.phar info -l parallel-lint.phar
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: parallel-lint-phar
           path: ./parallel-lint.phar
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -133,14 +133,14 @@ jobs:
 
       - name: Install Composer dependencies
         if: ${{ matrix.php != '8.4' }}
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Install Composer dependencies (PHP 8.4, ignore PHP reqs)"
         if: ${{ matrix.php == '8.4' }}
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
         with:
           composer-options: --ignore-platform-req=php
           custom-cache-suffix: $(date -u "+%Y-%m")
@@ -155,7 +155,7 @@ jobs:
       - name: 'Run unit tests'
         run: composer test
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: parallel-lint-phar
 


### PR DESCRIPTION
A number of predefined actions have had major releases, which warrant an update to the workflow(s).

These updates don't actually contain any changed functionality, they are mostly just a change of the Node version used by the action itself (from Node 16 to Node 20).

Refs:
* https://github.com/actions/checkout/releases
* https://github.com/actions/download-artifact/releases
* https://github.com/actions/upload-artifact/releases
* https://github.com/ramsey/composer-install/releases
* https://github.com/softprops/action-gh-release/releases