### PR TITLE
GH Actions: fix duplicate release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,19 +118,12 @@ jobs:
           name: parallel-lint-phar
 
       - name: Draft Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
           draft: true
           prerelease: false
-
-      - name: Upload Phar as Release Asset
-        id: upload-release-asset
-        uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
+          make_latest: true
           files: parallel-lint.phar
+          fail_on_unmatched_files: true


### PR DESCRIPTION
As things were, the workflow was creating two releases, one in draft and one published, but without a good name/changelog. I noticed this last time there was a release, but never got round to fixing it (and it wasn't urgent as no new release was needed).

As a new release is needed soon, now seemed like a good time to fix this.

The `actions/create-release` action runner has been abandoned and mentions the `softprops/action-gh-release` action runner as a replacement.

This commit now updates the workflow to solely use the `softprops/action-gh-release` action runner and updates the version and configuration to make sure it only creates a draft release, so we can still edit it and add the changelog before publishing.