### PR TITLE
Composer: add keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,10 @@
     "description": "This tool checks the syntax of PHP files about 20x faster than serial check.",
     "homepage": "https://github.com/php-parallel-lint/PHP-Parallel-Lint",
     "license": "BSD-2-Clause",
+    "keywords": [
+        "lint",
+        "static analysis"
+    ],
     "authors": [
         {
             "name": "Jakub Onderka",


### PR DESCRIPTION
As of Composer 2.4, Composer will recommend putting a dependency in `require-dev` over `require` when certain keywords are encountered.

As PHP Parallel Lint should be placed in `require-dev`, this commit adds those keywords to trigger this notification for end-users (when needed).

Closes #134