### PR TITLE
GH Actions: improve the draft release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,8 +120,8 @@ jobs:
       - name: Draft Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
           draft: true
           prerelease: false
           make_latest: true


### PR DESCRIPTION
Follow up on PR #159

This fixes the [following warning](https://github.com/php-parallel-lint/PHP-Parallel-Lint/actions/runs/8451602426):
```
Warning: Unexpected input(s) 'release_name', valid inputs are ['body', 'body_path', 'name', 'tag_name', 'draft', 'prerelease', 'files', 'fail_on_unmatched_files', 'repository', 'token', 'target_commitish', 'discussion_category_name', 'generate_release_notes', 'append_body', 'make_latest']
```

And should make sure the tag and the release name don't contain the `refs/heads/` part of the tag reference.