### PR TITLE
GH Actions/release: validate binary against PHP 8.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
   verify:
     name: Validate binary on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.php == '8.3' }}
+    continue-on-error: ${{ matrix.php == '8.4' }}
     needs:
       - bundle
 
@@ -86,6 +86,7 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Follow up on #150, which added PHP 8.4 to the test workflow, but didn't update the release workflow.

Fixed now.