### PR TITLE
Fix the php executable to handle folder name with spaces

### DIFF
--- a/src/Process/Process.php
+++ b/src/Process/Process.php
@@ -45,7 +45,7 @@ class Process
             self::STDERR => array('pipe', self::WRITE),
         );
 
-        $cmdLine = $executable . ' ' . implode(' ', array_map('escapeshellarg', $arguments));
+        $cmdLine = '"' . $executable . '" ' . implode(' ', array_map('escapeshellarg', $arguments));
         $this->process = proc_open($cmdLine, $descriptors, $pipes, null, null, array('bypass_shell' => true));
 
         if ($this->process === false || $this->process === null) {


### PR DESCRIPTION
As reported in https://github.com/beyondcode/herd-community/issues/631.