### PR TITLE
Add tests for paths with spaces

### DIFF
--- a/tests/Unit/SettingsAddPathsTest.php
+++ b/tests/Unit/SettingsAddPathsTest.php
@@ -59,6 +59,17 @@ class SettingsAddPathsTest extends UnitTestCase
                 'extra'    => array('path/1', 'path/subdir/3'),
                 'expected' => array('path/1', 'path/subdir/2', 'path/1', 'path/subdir/3'),
             ),
+            'Paths passed on CLI, paths with spaces' => array(
+                'original' => array('path with/spaces between/1', 'path with/spaces between/subdir/2'),
+                'extra'    => array('path/1', 'path/subdir/3', 'path/with spaces'),
+                'expected' => array(
+                    'path with/spaces between/1',
+                    'path with/spaces between/subdir/2',
+                    'path/1',
+                    'path/subdir/3',
+                    'path/with spaces'
+                ),
+            )
         );
     }
 }

--- a/tests/Unit/SettingsAddPathsTest.php
+++ b/tests/Unit/SettingsAddPathsTest.php
@@ -61,13 +61,21 @@ class SettingsAddPathsTest extends UnitTestCase
             ),
             'Paths passed on CLI, paths with spaces' => array(
                 'original' => array('path with/spaces between/1', 'path with/spaces between/subdir/2'),
-                'extra'    => array('path/1', 'path/subdir/3', 'path/with spaces'),
+                'extra'    => array(
+                    'path/1',
+                    'path/subdir/3',
+                    'path/with spaces',
+                    'windows-path\with spaces\and\backslashes',
+                    'windows path\with spaces\and\backslashes'
+                ),
                 'expected' => array(
                     'path with/spaces between/1',
                     'path with/spaces between/subdir/2',
                     'path/1',
                     'path/subdir/3',
-                    'path/with spaces'
+                    'path/with spaces',
+                    'windows-path\with spaces\and\backslashes',
+                    'windows path\with spaces\and\backslashes',
                 ),
             )
         );


### PR DESCRIPTION
Separated tests from #171 that will test if the paths passed on CLI with spaces will work.

Not sure if I should add more tests to cover Windows use cases (different directory separator)?