### PR TITLE
SkipLintProcess: Pass script by file-name instead of code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,8 +91,8 @@ jobs:
           path: ./parallel-lint.phar
 
   test:
-    name: Run tests on PHP ${{ matrix.php }}
-    runs-on: ubuntu-latest
+    name: Run tests on PHP ${{ matrix.php }} (${{ matrix.os }})
+    runs-on: "${{ matrix.os }}"
     continue-on-error: ${{ matrix.php == '8.4' }}
     needs:
       - bundle
@@ -114,6 +114,19 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
+        os:
+          - 'ubuntu-latest'
+
+        include:
+          # Also run the tests against Windows on a few PHP versions.
+          - php: '5.5'
+            os: 'windows-latest'
+          - php: '7.0'
+            os: 'windows-latest'
+          - php: '8.0'
+            os: 'windows-latest'
+          - php: '8.3'
+            os: 'windows-latest'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Grab PHPUnit version
         id: phpunit_version
         shell: bash
-        run: echo "VERSION=$(echo vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+        run: echo "VERSION=$(php vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
 
       - name: "Run unit tests (PHPUnit < 10)"
         if: ${{ ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,13 +167,14 @@ jobs:
 
       - name: Grab PHPUnit version
         id: phpunit_version
-        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+        shell: bash
+        run: echo "VERSION=$(echo vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
 
       - name: "Run unit tests (PHPUnit < 10)"
         if: ${{ ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
         run: composer test
 
-      - name: "Run unit tests (PHPUnit < 10)"
+      - name: "Run unit tests (PHPUnit >= 10)"
         if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
         run: composer test10
 

--- a/src/Process/SkipLintProcess.php
+++ b/src/Process/SkipLintProcess.php
@@ -23,15 +23,12 @@ class SkipLintProcess extends PhpProcess
     public function __construct(PhpExecutable $phpExecutable, array $filesToCheck)
     {
         $scriptPath = __DIR__ . '/../../bin/skip-linting.php';
-        $script = file_get_contents($scriptPath);
 
-        if (!$script) {
+        if (!is_file($scriptPath)) {
             throw new RuntimeException("skip-linting.php script not found in '$scriptPath'.");
         }
 
-        $script = str_replace('<?php', '', $script);
-
-        $parameters = array('-d', 'display_errors=stderr', '-r', $script);
+        $parameters = array('-d', 'display_errors=stderr', '-f', realpath($scriptPath));
         parent::__construct($phpExecutable, $parameters, implode(PHP_EOL, $filesToCheck));
     }
 

--- a/src/Process/SkipLintProcess.php
+++ b/src/Process/SkipLintProcess.php
@@ -22,13 +22,10 @@ class SkipLintProcess extends PhpProcess
      */
     public function __construct(PhpExecutable $phpExecutable, array $filesToCheck)
     {
-        $scriptPath = __DIR__ . '/../../bin/skip-linting.php';
+        $scriptPath = dirname(dirname(__DIR__)) . '/bin/skip-linting.php';
+        $code = sprintf("include('%s');", $scriptPath);
 
-        if (!is_file($scriptPath)) {
-            throw new RuntimeException("skip-linting.php script not found in '$scriptPath'.");
-        }
-
-        $parameters = array('-d', 'display_errors=stderr', '-f', realpath($scriptPath));
+        $parameters = array('-d', 'display_errors=stderr', '-r', $code);
         parent::__construct($phpExecutable, $parameters, implode(PHP_EOL, $filesToCheck));
     }
 


### PR DESCRIPTION
Fixes the windows test-failure indentified in https://github.com/php-parallel-lint/PHP-Parallel-Lint/pull/170 by ~~passing the script path to `SkipLintProcess`~~ include instead of passing the code as a string which get mangled by later `escapeshellarg()`.

see https://github.com/php/php-src/issues/16147#issuecomment-2385484110 for a in-detail analysis why this did not work on windows - kudos to Christoph M. Becker for the root cause analysis.

closes https://github.com/php-parallel-lint/PHP-Parallel-Lint/pull/170