### PR TITLE
GH Actions: PHP 8.4 has been released

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
   verify:
     name: Validate binary on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.php == '8.4' }}
+    continue-on-error: ${{ matrix.php == '8.5' }}
     needs:
       - bundle
 
@@ -87,6 +87,7 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
+          - '8.5'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
   test:
     name: Run tests on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.php == '8.4' }}
+    continue-on-error: ${{ matrix.php == '8.5' }}
     needs:
       - bundle
 
@@ -114,6 +114,7 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
+          - '8.5'
 
     steps:
       - name: Checkout code
@@ -132,14 +133,14 @@ jobs:
         run: composer remove --dev php-parallel-lint/php-code-style --no-update --no-interaction
 
       - name: Install Composer dependencies
-        if: ${{ matrix.php != '8.4' }}
+        if: ${{ matrix.php != '8.5' }}
         uses: ramsey/composer-install@v3
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      - name: "Install Composer dependencies (PHP 8.4, ignore PHP reqs)"
-        if: ${{ matrix.php == '8.4' }}
+      - name: "Install Composer dependencies (PHP nightly, ignore PHP reqs)"
+        if: ${{ matrix.php == '8.5' }}
         uses: ramsey/composer-install@v3
         with:
           composer-options: --ignore-platform-req=php

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Additionally `blame` can be used to show commits that introduced the breakage.
 
 Running parallel jobs in PHP is inspired by Nette framework tests.
 
-The application is officially supported for use with PHP 5.3 to 8.3.
+The application is officially supported for use with PHP 5.3 to 8.4.
 
 ## Table of contents
 


### PR DESCRIPTION
* Builds against PHP 8.4 are no longer allowed to fail.
* Add _allowed to fail_ build against PHP 8.5.
* Update the README.

Ref: https://www.php.net/releases/8.4/en.php