### PR TITLE
Update README.md: code quality link became stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ It is strongly recommended for existing users of the (unmaintained)
 - `--no-progress`           Disable progress in console output.
 - `--checkstyle`            Output results as Checkstyle XML.
 - `--json`                  Output results as JSON string (requires PHP 5.4).
-- `--gitlab`                Output results for the GitLab Code Quality Widget (requires PHP 5.4), see more in [Code Quality](https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html) documentation..
+- `--gitlab`                Output results for the GitLab Code Quality Widget (requires PHP 5.4), see more in [Code Quality](https://docs.gitlab.com/ee/ci/testing/code_quality.html) documentation..
 - `--blame`                 Try to show git blame for row with error.
 - `--git <git>`             Path to Git executable to show blame message (default: 'git').
 - `--stdin`                 Load files and folder to test from standard input.


### PR DESCRIPTION
GitLab documentation has been updated and the link didn't work.