### PR TITLE
GH Actions: change PHAR building to reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,50 +18,8 @@ jobs:
     # Don't run on forks.
     if: github.repository == 'php-parallel-lint/PHP-Parallel-Lint'
 
-    name: Bundle binary
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.2
-          extensions: exif, phar, openssl, sodium
-          coverage: none
-          ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, display_startup_errors=On, zend.assertions=1
-          # Autoload files generated with Composer 2.3 are not compatible with PHP < 7.0.
-          tools: composer:2.2
-        env:
-          fail-fast: true
-
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
-        with:
-          composer-options: "--no-dev"
-          # Bust the cache at least once a month - output format: YYYY-MM.
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
-      # Note: do NOT turn on the requirement checker in the box config as it is no longer
-      # compatible with PHP < 7.2.
-      - name: Install Box
-        run: wget https://github.com/box-project/box/releases/latest/download/box.phar -O box.phar && chmod 0755 box.phar && pwd
-
-      - name: Validate configuration
-        run: php box.phar validate -i box.json
-
-      - name: Building binary...
-        run: php box.phar compile -v --config=box.json
-
-      - name: Show info about the build phar with box-project/box
-        run: php box.phar info -l parallel-lint.phar
-
-      - uses: actions/upload-artifact@v6
-        with:
-          name: parallel-lint-phar
-          path: ./parallel-lint.phar
+    name: Build binary
+    uses: ./.github/workflows/reusable-build-binary.yml
 
   verify:
     name: Validate binary on PHP ${{ matrix.php }}

--- a/.github/workflows/reusable-build-binary.yml
+++ b/.github/workflows/reusable-build-binary.yml
@@ -1,0 +1,52 @@
+name: Build Binary
+
+on:
+  workflow_call:
+
+jobs:
+  bundle:
+    name: Build binary
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          extensions: exif, phar, openssl, sodium
+          coverage: none
+          ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, display_startup_errors=On, zend.assertions=1
+          # Autoload files generated with Composer 2.3 are not compatible with PHP < 7.0.
+          tools: composer:2.2
+        env:
+          fail-fast: true
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: "--no-dev"
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
+
+      # Note: do NOT turn on the requirement checker in the box config as it is no longer
+      # compatible with PHP < 7.2.
+      - name: Install Box
+        run: wget https://github.com/box-project/box/releases/latest/download/box.phar -O box.phar && chmod 0755 box.phar && pwd
+
+      - name: Validate configuration
+        run: php box.phar validate -i box.json
+
+      - name: Building binary...
+        run: php box.phar compile -v --config=box.json
+
+      - name: Show info about the build phar with box-project/box
+        run: php box.phar info -l parallel-lint.phar
+
+      - name: Upload PHAR to workflow summary
+        uses: actions/upload-artifact@v6
+        with:
+          name: parallel-lint-phar
+          path: ./parallel-lint.phar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,50 +45,8 @@ jobs:
         run: cs2pr ./phpcs-report.xml
 
   bundle:
-    name: Bundle binary
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.2
-          extensions: exif, phar, openssl, sodium
-          coverage: none
-          ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, display_startup_errors=On, zend.assertions=1
-          # Autoload files generated with Composer 2.3 are not compatible with PHP < 7.0.
-          tools: composer:2.2
-        env:
-          fail-fast: true
-
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
-        with:
-          composer-options: "--no-dev"
-          # Bust the cache at least once a month - output format: YYYY-MM.
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
-      # Note: do NOT turn on the requirement checker in the box config as it is no longer
-      # compatible with PHP < 7.2.
-      - name: Install Box
-        run: wget https://github.com/box-project/box/releases/latest/download/box.phar -O box.phar && chmod 0755 box.phar && pwd
-
-      - name: Validate configuration
-        run: php box.phar validate -i box.json
-
-      - name: Building binary...
-        run: php box.phar compile -v --config=box.json
-
-      - name: Show info about the build phar with box-project/box
-        run: php box.phar info -l parallel-lint.phar
-
-      - uses: actions/upload-artifact@v6
-        with:
-          name: parallel-lint-phar
-          path: ./parallel-lint.phar
+    name: Build binary
+    uses: ./.github/workflows/reusable-build-binary.yml
 
   test:
     name: Run tests on PHP ${{ matrix.php }}


### PR DESCRIPTION
The workflows currently contain two jobs which build the PHAR files. This means that any changes to the steps in these jobs have to be made in two places.

With this in mind, it makes sense to change the PHAR building to a reusable workflow, which can then be used by both jobs. With this change, any changes to the steps of the job will only need to be made in one place.

This commit makes it so.