### PR TITLE
Fix: force the use of colors when the '--colors' flag is supplied.

### DIFF
--- a/src/ErrorFormatter.php
+++ b/src/ErrorFormatter.php
@@ -20,10 +20,10 @@ class ErrorFormatter
     /** @var bool */
     private $translateTokens;
 
-    public function __construct($useColors = Settings::AUTODETECT, $translateTokens = false, $forceColors = false)
+    public function __construct($useColors = Settings::AUTODETECT, $translateTokens = false)
     {
         $this->useColors = $useColors;
-        $this->forceColors = $forceColors;
+        $this->forceColors = $useColors === Settings::FORCED;
         $this->translateTokens = $translateTokens;
     }
 


### PR DESCRIPTION
When the `php-parallel-lint` command is ran as a subcommand, and the `--colors` flag is used, it is not honoured. This fixes this, and allows for coloured output when forced.