### PR TITLE
GH Actions: update for the release of PHP 8.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
   verify:
     name: Validate binary on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.php == '8.5' }}
+    continue-on-error: ${{ matrix.php == '8.6' }}
     needs:
       - bundle
 
@@ -88,6 +88,7 @@ jobs:
           - '8.3'
           - '8.4'
           - '8.5'
+          - '8.6'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
   test:
     name: Run tests on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.php == '8.5' }}
+    continue-on-error: ${{ matrix.php == '8.6' }}
     needs:
       - bundle
 
@@ -115,6 +115,7 @@ jobs:
           - '8.3'
           - '8.4'
           - '8.5'
+          - '8.6'
 
     steps:
       - name: Checkout code
@@ -133,14 +134,14 @@ jobs:
         run: composer remove --dev php-parallel-lint/php-code-style --no-update --no-interaction
 
       - name: Install Composer dependencies
-        if: ${{ matrix.php != '8.5' }}
+        if: ${{ matrix.php != '8.6' }}
         uses: ramsey/composer-install@v3
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Install Composer dependencies (PHP nightly, ignore PHP reqs)"
-        if: ${{ matrix.php == '8.5' }}
+        if: ${{ matrix.php == '8.6' }}
         uses: ramsey/composer-install@v3
         with:
           composer-options: --ignore-platform-req=php

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Additionally `blame` can be used to show commits that introduced the breakage.
 
 Running parallel jobs in PHP is inspired by Nette framework tests.
 
-The application is officially supported for use with PHP 5.3 to 8.4.
+The application is officially supported for use with PHP 5.3 to 8.5.
 
 ## Table of contents
 


### PR DESCRIPTION
... which is expected to be released this Thursday.

* Builds against PHP 8.5 are no longer allowed to fail.
* Add _allowed to fail_ build against PHP 8.6.
* Update the README.