### PR TITLE
Add cache functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 /build
 /vendor
 composer.lock
+.parallel-lint-cache.json
+.parallel-lint-cache.json.*.tmp
+.parallel-lint-cache.json.lock
 .phpcs.xml
 phpcs.xml
 .phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ It is strongly recommended for existing users of the (unmaintained)
 - `--ignore-fails`          Ignore failed tests.
 - `--show-deprecated`       Show deprecations (default: Off).
 - `--syntax-error-callback` File with syntax error callback for ability to modify error, see more in [example](doc/syntax-error-callback.md).
+- `--cache`                 Enable file content caching. Unchanged files skip linting on subsequent runs.
+- `--cache-file <file>`     Specify cache file location (implies `--cache`). (default: .parallel-lint-cache.json)
 - `-h`, `--help`            Print this help.
 - `-V`, `--version`         Display the application version
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -102,6 +102,10 @@ Options:
     --ignore-fails          Ignore failed tests.
     --show-deprecated       Show deprecations (default: Off).
     --syntax-error-callback File with syntax error callback for ability to modify error
+    --cache                 Enable file content caching. Unchanged files skip linting
+                            on subsequent runs.
+    --cache-file <file>     Specify cache file location (implies --cache).
+                            (default: .parallel-lint-cache.json)
     -h, --help              Print this help.
     -V, --version           Display the application version
 
@@ -125,7 +129,7 @@ HELP;
         echo <<<USAGE
 -------------------------------
 Usage:
-parallel-lint [sa] [-p php] [-e ext] [-j num] [--exclude dir] [files or directories]
+parallel-lint [sa] [-p php] [-e ext] [-j num] [--cache] [--cache-file <file>] [--exclude dir] [files or directories]
 
 USAGE;
         $this->showOptions();

--- a/src/Cache/LintCache.php
+++ b/src/Cache/LintCache.php
@@ -180,89 +180,11 @@ class LintCache
             return;
         }
 
-        $lockFile = $this->cacheFilePath . '.lock';
-        $lockHandle = fopen($lockFile, 'cb');
-        if ($lockHandle === false) {
-            return;
-        }
-
-        if (!flock($lockHandle, LOCK_EX)) {
-            fclose($lockHandle);
-            return;
-        }
-
-        $this->mergeFromDisk();
-
-        // Merge disk entries for the active key, with in-memory values taking precedence
-        $diskEntries = array();
-        if (isset($this->allEntries[$this->cacheKey]) && is_array($this->allEntries[$this->cacheKey])) {
-            $diskEntries = $this->allEntries[$this->cacheKey];
-        }
-        $this->allEntries[$this->cacheKey] = array_merge($diskEntries, $this->entries);
+        $this->allEntries[$this->cacheKey] = $this->entries;
 
         $json = json_encode($this->allEntries);
-        if ($json !== false && $this->writeCacheFile($json)) {
+        if ($json !== false && file_put_contents($this->cacheFilePath, $json) !== false) {
             $this->dirty = false;
         }
-
-        flock($lockHandle, LOCK_UN);
-        fclose($lockHandle);
-    }
-
-    /**
-     * Re-read cache file from disk to merge entries from concurrent runs
-     */
-    private function mergeFromDisk()
-    {
-        if (!is_file($this->cacheFilePath)) {
-            return;
-        }
-
-        $contents = file_get_contents($this->cacheFilePath);
-        if ($contents === false) {
-            return;
-        }
-
-        $diskData = json_decode($contents, true);
-        if (is_array($diskData)) {
-            $this->allEntries = $diskData;
-        }
-    }
-
-    /**
-     * Atomically write cache data to disk via a temp file
-     *
-     * @param string $json
-     * @return bool
-     */
-    private function writeCacheFile($json)
-    {
-        $tmpFile = $this->cacheFilePath . '.' . getmypid() . '.tmp';
-
-        if (file_put_contents($tmpFile, $json, LOCK_EX) === false) {
-            return false;
-        }
-
-        if (rename($tmpFile, $this->cacheFilePath)) {
-            return true;
-        }
-
-        // Fallback for Windows where rename() fails if target exists
-        if (file_exists($this->cacheFilePath) && !unlink($this->cacheFilePath)) {
-            unlink($tmpFile);
-            return false;
-        }
-
-        if (rename($tmpFile, $this->cacheFilePath)) {
-            return true;
-        }
-
-        if (copy($tmpFile, $this->cacheFilePath)) {
-            unlink($tmpFile);
-            return true;
-        }
-
-        unlink($tmpFile);
-        return false;
     }
 }

--- a/src/Cache/LintCache.php
+++ b/src/Cache/LintCache.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace PHP_Parallel_Lint\PhpParallelLint\Cache;
+
+class LintCache
+{
+    /** @var string */
+    private $cacheFilePath;
+
+    /** @var array All cache data keyed by settings key */
+    private $allEntries = array();
+
+    /** @var array Entries for the active cache key */
+    private $entries = array();
+
+    /** @var string */
+    private $cacheKey = '';
+
+    /** @var bool */
+    private $dirty = false;
+
+    const DEFAULT_CACHE_FILENAME = '.parallel-lint-cache.json';
+
+    /**
+     * @param string $cacheFilePath
+     */
+    public function __construct($cacheFilePath)
+    {
+        $this->cacheFilePath = $cacheFilePath;
+    }
+
+    /**
+     * @param string|null $customPath
+     * @return string
+     */
+    public static function getCacheFilePath($customPath)
+    {
+        if ($customPath !== null) {
+            return $customPath;
+        }
+
+        $currentWorkingDirectory = getcwd();
+        if ($currentWorkingDirectory === false) {
+            $currentWorkingDirectory = '.';
+        }
+
+        return $currentWorkingDirectory . DIRECTORY_SEPARATOR . self::DEFAULT_CACHE_FILENAME;
+    }
+
+    /**
+     * @param int $phpVersionId
+     * @param bool $aspTags
+     * @param bool $shortTag
+     * @param bool $showDeprecated
+     * @return string
+     */
+    public static function buildCacheKey($phpVersionId, $aspTags, $shortTag, $showDeprecated)
+    {
+        return 'php:' . $phpVersionId
+            . '|asp:' . ($aspTags ? '1' : '0')
+            . '|short:' . ($shortTag ? '1' : '0')
+            . '|dep:' . ($showDeprecated ? '1' : '0');
+    }
+
+    /**
+     * @param string $cacheKey
+     * @return LintCache
+     */
+    public function load($cacheKey)
+    {
+        $this->cacheKey = $cacheKey;
+        $this->allEntries = array();
+        $this->entries = array();
+        $this->dirty = false;
+
+        if (!is_file($this->cacheFilePath)) {
+            return $this;
+        }
+
+        $contents = file_get_contents($this->cacheFilePath);
+        if ($contents === false) {
+            return $this;
+        }
+
+        $data = json_decode($contents, true);
+        if (!is_array($data)) {
+            return $this;
+        }
+
+        $this->allEntries = $data;
+
+        if (isset($this->allEntries[$cacheKey]) && is_array($this->allEntries[$cacheKey])) {
+            $this->entries = $this->allEntries[$cacheKey];
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param array $files
+     * @return array with keys 'uncached' and 'cached'
+     */
+    public function filterFiles(array $files)
+    {
+        // No cached entries to compare against, skip md5_file() on every file
+        if (empty($this->entries)) {
+            return array('uncached' => $files, 'cached' => array());
+        }
+
+        $uncached = array();
+        $cached = array();
+
+        foreach ($files as $file) {
+            $checksum = $this->getFileChecksum($file);
+            if ($checksum === false) {
+                $uncached[] = $file;
+                $this->evictEntry($file);
+                continue;
+            }
+
+            if (isset($this->entries[$file]) && $this->entries[$file] === $checksum) {
+                $cached[] = $file;
+            } else {
+                $uncached[] = $file;
+            }
+        }
+
+        return array('uncached' => $uncached, 'cached' => $cached);
+    }
+
+    /**
+     * @param string $filePath
+     */
+    public function recordSuccess($filePath)
+    {
+        $checksum = $this->getFileChecksum($filePath);
+        if ($checksum === false) {
+            return;
+        }
+
+        $this->entries[$filePath] = $checksum;
+        $this->dirty = true;
+    }
+
+    /**
+     * @param string $filePath
+     */
+    public function recordFailure($filePath)
+    {
+        $this->evictEntry($filePath);
+    }
+
+    /**
+     * @param string $file
+     * @return string|false
+     */
+    private function getFileChecksum($file)
+    {
+        if (!is_readable($file)) {
+            return false;
+        }
+
+        return md5_file($file);
+    }
+
+    /**
+     * @param string $file
+     */
+    private function evictEntry($file)
+    {
+        if (isset($this->entries[$file])) {
+            unset($this->entries[$file]);
+            $this->dirty = true;
+        }
+    }
+
+    public function save()
+    {
+        if (!$this->dirty) {
+            return;
+        }
+
+        $lockFile = $this->cacheFilePath . '.lock';
+        $lockHandle = fopen($lockFile, 'cb');
+        if ($lockHandle === false) {
+            return;
+        }
+
+        if (!flock($lockHandle, LOCK_EX)) {
+            fclose($lockHandle);
+            return;
+        }
+
+        $this->mergeFromDisk();
+
+        // Merge disk entries for the active key, with in-memory values taking precedence
+        $diskEntries = array();
+        if (isset($this->allEntries[$this->cacheKey]) && is_array($this->allEntries[$this->cacheKey])) {
+            $diskEntries = $this->allEntries[$this->cacheKey];
+        }
+        $this->allEntries[$this->cacheKey] = array_merge($diskEntries, $this->entries);
+
+        $json = json_encode($this->allEntries);
+        if ($json !== false && $this->writeCacheFile($json)) {
+            $this->dirty = false;
+        }
+
+        flock($lockHandle, LOCK_UN);
+        fclose($lockHandle);
+    }
+
+    /**
+     * Re-read cache file from disk to merge entries from concurrent runs
+     */
+    private function mergeFromDisk()
+    {
+        if (!is_file($this->cacheFilePath)) {
+            return;
+        }
+
+        $contents = file_get_contents($this->cacheFilePath);
+        if ($contents === false) {
+            return;
+        }
+
+        $diskData = json_decode($contents, true);
+        if (is_array($diskData)) {
+            $this->allEntries = $diskData;
+        }
+    }
+
+    /**
+     * Atomically write cache data to disk via a temp file
+     *
+     * @param string $json
+     * @return bool
+     */
+    private function writeCacheFile($json)
+    {
+        $tmpFile = $this->cacheFilePath . '.' . getmypid() . '.tmp';
+
+        if (file_put_contents($tmpFile, $json, LOCK_EX) === false) {
+            return false;
+        }
+
+        if (rename($tmpFile, $this->cacheFilePath)) {
+            return true;
+        }
+
+        // Fallback for Windows where rename() fails if target exists
+        if (file_exists($this->cacheFilePath) && !unlink($this->cacheFilePath)) {
+            unlink($tmpFile);
+            return false;
+        }
+
+        if (rename($tmpFile, $this->cacheFilePath)) {
+            return true;
+        }
+
+        if (copy($tmpFile, $this->cacheFilePath)) {
+            unlink($tmpFile);
+            return true;
+        }
+
+        unlink($tmpFile);
+        return false;
+    }
+}

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -10,6 +10,7 @@ use PHP_Parallel_Lint\PhpParallelLint\Exceptions\ClassNotFoundException;
 use PHP_Parallel_Lint\PhpParallelLint\Exceptions\ParallelLintException;
 use PHP_Parallel_Lint\PhpParallelLint\Exceptions\PathNotFoundException;
 use PHP_Parallel_Lint\PhpParallelLint\Iterators\RecursiveDirectoryFilterIterator;
+use PHP_Parallel_Lint\PhpParallelLint\Cache\LintCache;
 use PHP_Parallel_Lint\PhpParallelLint\Outputs\CheckstyleOutput;
 use PHP_Parallel_Lint\PhpParallelLint\Outputs\GitLabOutput;
 use PHP_Parallel_Lint\PhpParallelLint\Outputs\JsonOutput;
@@ -50,7 +51,20 @@ class Manager
             throw new ParallelLintException('No file found to check.');
         }
 
-        $output->setTotalFileCount(count($files));
+        $cachedFiles = array();
+        $lintCache = null;
+
+        if ($settings->cache) {
+            $lintCache = $this->createLintCache($settings, $phpExecutable);
+
+            $filterResult = $lintCache->filterFiles($files);
+            $cachedFiles = $filterResult['cached'];
+            $files = $filterResult['uncached'];
+        }
+
+        array_map(array($output, 'ok'), $cachedFiles);
+
+        $output->setTotalFileCount(count($files) + count($cachedFiles));
 
         $parallelLint = new ParallelLint($phpExecutable, $settings->parallelJobs);
         $parallelLint->setAspTagsEnabled($settings->aspTags);
@@ -71,6 +85,17 @@ class Manager
         });
 
         $result = $parallelLint->lint($files);
+
+        $this->updateLintCache($lintCache, $result);
+
+        if (!empty($cachedFiles)) {
+            $result = new Result(
+                $result->getErrors(),
+                $result->getCheckedFiles(),
+                array_merge($cachedFiles, $result->getSkippedFiles()),
+                $result->getTestTime()
+            );
+        }
 
         if ($settings->blame) {
             $this->gitBlame($result, $settings);
@@ -114,6 +139,52 @@ class Manager
         $output->showProgress = $settings->showProgress;
 
         return $output;
+    }
+
+    /**
+     * @param Settings $settings
+     * @param PhpExecutable $phpExecutable
+     * @return LintCache
+     */
+    protected function createLintCache(Settings $settings, PhpExecutable $phpExecutable)
+    {
+        $cacheFilePath = LintCache::getCacheFilePath($settings->cacheFile);
+        $cacheKey = LintCache::buildCacheKey(
+            $phpExecutable->getVersionId(),
+            $settings->aspTags,
+            $settings->shortTag,
+            $settings->showDeprecated
+        );
+
+        $lintCache = new LintCache($cacheFilePath);
+        $lintCache->load($cacheKey);
+
+        return $lintCache;
+    }
+
+    /**
+     * @param LintCache|null $lintCache
+     * @param Result $result
+     */
+    protected function updateLintCache($lintCache, Result $result)
+    {
+        if (!$lintCache instanceof LintCache) {
+            return;
+        }
+
+        $erroredPaths = array();
+        foreach ($result->getErrors() as $error) {
+            $erroredPaths[$error->getFilePath()] = true;
+            $lintCache->recordFailure($error->getFilePath());
+        }
+
+        foreach ($result->getCheckedFiles() as $file) {
+            if (!isset($erroredPaths[$file])) {
+                $lintCache->recordSuccess($file);
+            }
+        }
+
+        $lintCache->save();
     }
 
     /**

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -114,6 +114,18 @@ class Settings
     public $syntaxErrorCallbackFile = null;
 
     /**
+     * Enable checksum-based caching to skip unchanged files
+     * @var bool
+     */
+    public $cache = false;
+
+    /**
+     * Path to the cache file
+     * @var string|null
+     */
+    public $cacheFile = null;
+
+    /**
      * @param array $paths
      */
     public function addPaths(array $paths)
@@ -214,6 +226,15 @@ class Settings
 
                     case '--syntax-error-callback':
                         $settings->syntaxErrorCallbackFile = $arguments->getNext();
+                        break;
+
+                    case '--cache':
+                        $settings->cache = true;
+                        break;
+
+                    case '--cache-file':
+                        $settings->cache = true;
+                        $settings->cacheFile = $arguments->getNext();
                         break;
 
                     default:

--- a/tests/Unit/ManagerRunTest.php
+++ b/tests/Unit/ManagerRunTest.php
@@ -102,6 +102,83 @@ class ManagerRunTest extends UnitTestCase
         $this->assertFalse($result->hasError());
     }
 
+    public function testCachePopulatesOnFirstRun()
+    {
+        $cacheFile = $this->getCacheFilePath();
+
+        $settings = $this->prepareSettings();
+        $settings->paths = array('tests/fixtures/fixture-02/');
+        $settings->cache = true;
+        $settings->cacheFile = $cacheFile;
+
+        $manager = $this->getManager($settings);
+        $result = $manager->run($settings);
+        $this->assertFalse($result->hasError());
+        $this->assertGreaterThan(0, $result->getCheckedFilesCount());
+        $this->assertFileExists($cacheFile);
+    }
+
+    public function testCacheReusesOnSecondRun()
+    {
+        $cacheFile = $this->getCacheFilePath();
+
+        $settings = $this->prepareSettings();
+        $settings->paths = array('tests/fixtures/fixture-02/');
+        $settings->cache = true;
+        $settings->cacheFile = $cacheFile;
+
+        // First run: populate cache
+        $manager = $this->getManager($settings);
+        $firstResult = $manager->run($settings);
+        $firstChecked = $firstResult->getCheckedFilesCount();
+        $this->assertGreaterThan(0, $firstChecked);
+
+        // Second run: all files served from cache, none actually linted
+        $manager = $this->getManager($settings);
+        $secondResult = $manager->run($settings);
+        $this->assertFalse($secondResult->hasError());
+        $this->assertSame(0, $secondResult->getCheckedFilesCount());
+        $this->assertSame($firstChecked, $secondResult->getSkippedFilesCount());
+    }
+
+    public function testCacheDoesNotCacheErrors()
+    {
+        $cacheFile = $this->getCacheFilePath();
+
+        $settings = $this->prepareSettings();
+        $settings->paths = array('tests/fixtures/fixture-03/');
+        $settings->cache = true;
+        $settings->cacheFile = $cacheFile;
+
+        // First run: file has syntax error
+        $manager = $this->getManager($settings);
+        $firstResult = $manager->run($settings);
+        $this->assertTrue($firstResult->hasError());
+
+        // Second run: error should still be reported (not cached)
+        $manager = $this->getManager($settings);
+        $secondResult = $manager->run($settings);
+        $this->assertTrue($secondResult->hasError());
+        $this->assertSame(
+            $firstResult->getFilesWithSyntaxErrorCount(),
+            $secondResult->getFilesWithSyntaxErrorCount()
+        );
+    }
+
+    public function testCacheWithoutFlagDoesNotCreateFile()
+    {
+        $cacheFile = $this->getCacheFilePath();
+
+        $settings = $this->prepareSettings();
+        $settings->paths = array('tests/fixtures/fixture-02/');
+        $settings->cache = false;
+        $settings->cacheFile = $cacheFile;
+
+        $manager = $this->getManager($settings);
+        $manager->run($settings);
+        $this->assertFileNotExistsPolyfill($cacheFile);
+    }
+
     /**
      * @param Settings $settings
      * @return Manager
@@ -129,5 +206,40 @@ class ManagerRunTest extends UnitTestCase
         $settings->colors = false;
 
         return $settings;
+    }
+
+    /**
+     * @return string
+     */
+    private function getCacheFilePath()
+    {
+        return sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'parallel-lint-test-' . getmypid() . '.json';
+    }
+
+    /**
+     * Clean up cache files after each test.
+     *
+     * @after
+     */
+    public function removeCacheFile()
+    {
+        $cacheFile = $this->getCacheFilePath();
+        if (is_file($cacheFile)) {
+            unlink($cacheFile);
+        }
+    }
+
+    /**
+     * PHPUnit polyfill for assertFileDoesNotExist (PHPUnit < 9).
+     *
+     * @param string $file
+     */
+    private function assertFileNotExistsPolyfill($file)
+    {
+        if (method_exists($this, 'assertFileDoesNotExist')) {
+            $this->assertFileDoesNotExist($file);
+        } else {
+            $this->assertFalse(is_file($file), "File $file should not exist");
+        }
     }
 }


### PR DESCRIPTION
This PR adds a cache functionality in the form of a JSON file that collects checksum of files with successful lints (tied to a cache key). 

The cache functionality is optional.

There is an option to designate a cache file.

Concurrent runs of lint are supported in [7c2c4a0](https://github.com/php-parallel-lint/PHP-Parallel-Lint/pull/203/commits/7c2c4a0ee65889f05ae2d9fa1126be63f82ae9a1).

Unit tests are added.