### PR TITLE
GH Actions: fail "setup-php" if requested tooling could not be installed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: error_reporting=-1, display_errors=On, display_startup_errors=On, zend.assertions=1
           coverage: none
+        env:
+          fail-fast: true
 
       - name: Run linter against codebase
         run: php ./parallel-lint.phar src/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,8 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: error_reporting=-1, display_errors=On, display_startup_errors=On, zend.assertions=1
           coverage: none
+        env:
+          fail-fast: true
 
       # Remove the PHPCS standard as it has a minimum PHP requirements of PHP 5.4 and would block install on PHP 5.3.
       - name: 'Composer: remove PHPCS'


### PR DESCRIPTION
Setup-PHP will normally "gracefully" show a warning and not fail the build when an extension or tool failed to install.

In most cases, this is not particularly useful as that means that either there will be a failure later on in the build due to the extension or tool missing, or the build will not be representative of what is supposed to be tested.

This commit changes this behaviour to fail select builds at the `setup-php` step, which also makes debugging these type of build failures much more straight-forward.

Ref: https://github.com/shivammathur/setup-php?tab=readme-ov-file#fail-fast-optional